### PR TITLE
fix(codeql): triage all 477 error alerts, fix 139 real ones, clear 2 generator false positives

### DIFF
--- a/src/AiDotNet.Generators/LayerStateGenerator.cs
+++ b/src/AiDotNet.Generators/LayerStateGenerator.cs
@@ -287,11 +287,22 @@ public class LayerStateGenerator : IIncrementalGenerator
         // it however correct its state declarations are. Declined rather than reported: the author
         // of a private helper layer has done nothing wrong, and ADN0055 firing on it is a
         // diagnostic about the table's reach rather than about their code.
-        for (var scope = type; scope is not null; scope = scope.ContainingType)
+        //
+        // A do/while, not `for (var scope = type; scope is not null; ...)`: the for-form tests the
+        // loop variable against null while it still aliases `type` (first iteration), and CodeQL's
+        // nullness analysis (cs/dereferenced-value-is-always-null) does not separate that iteration
+        // from later ones, so it carried the loop-exit fact "scope is null" back onto `type` and
+        // reported the `type.TypeKind` dereference below as always null. `type` is never null here
+        // -- `type.IsAbstract` above already dereferenced it -- so only ContainingType links are
+        // null-tested.
+        INamedTypeSymbol? scope = type;
+        do
         {
             if (scope.DeclaredAccessibility is Accessibility.Private or Accessibility.ProtectedAndInternal)
                 return null;
+            scope = scope.ContainingType;
         }
+        while (scope is not null);
 
         // THE HOST TYPE MUST BE ABLE TO CARRY THE GENERATED MEMBER. Analyze accepted any
         // constructor whose parameters carried [LayerState] and then emitted

--- a/src/AiDotNet.Generators/YamlConfigSourceGenerator.cs
+++ b/src/AiDotNet.Generators/YamlConfigSourceGenerator.cs
@@ -1470,15 +1470,29 @@ internal static class YamlParamsHelper
         };
     }
 
+    // Both walks below start at a non-null symbol and null-test only the ContainingType links
+    // (do/while). In the previous `for (current = symbol; current is not null; ...)` / `while` form,
+    // the `return true` was reached only by leaving the loop with `current` null, and CodeQL's
+    // nullness analysis does not separate the first iteration (where `current` IS `symbol`) from
+    // later ones: it inferred "returns true => symbol is null" and treated each helper as a
+    // null-check method. The caller's `if (!A(symbol) || !B(symbol)) return ...;` fall-through then
+    // read as "symbol is null", and `symbol.Constructors` in GetSelfImplementationIfRegisterable was
+    // reported as an always-null dereference (cs/dereferenced-value-is-always-null; either helper
+    // alone reproduces it). The symbol is never null: the only caller passes a type it has already
+    // dereferenced.
     private static bool IsEffectivelyPublicForGeneratedCode(INamedTypeSymbol symbol)
     {
-        for (INamedTypeSymbol? current = symbol; current is not null; current = current.ContainingType)
+        INamedTypeSymbol? current = symbol;
+        do
         {
             if (current.DeclaredAccessibility != Accessibility.Public)
             {
                 return false;
             }
+
+            current = current.ContainingType;
         }
+        while (current is not null);
 
         return true;
     }
@@ -1487,12 +1501,13 @@ internal static class YamlParamsHelper
     {
         var allowed = new HashSet<string>(StringComparer.Ordinal) { "T", "TInput", "TOutput" };
         var allTypeParams = new List<ITypeParameterSymbol>();
-        var current = symbol;
-        while (current is not null)
+        INamedTypeSymbol? current = symbol;
+        do
         {
             allTypeParams.AddRange(current.TypeParameters);
             current = current.ContainingType;
         }
+        while (current is not null);
 
         foreach (var tp in allTypeParams)
         {

--- a/src/AiModelBuilder.Configure.cs
+++ b/src/AiModelBuilder.Configure.cs
@@ -2588,7 +2588,6 @@ public partial class AiModelBuilder<T, TInput, TOutput>
 
         // Track training metrics
         var episodeRewards = new List<T>();
-        var episodeLengths = new List<int>();
         var losses = new List<T>();
         var stopwatch = System.Diagnostics.Stopwatch.StartNew();
         int totalStepsAcrossEpisodes = 0;
@@ -2710,7 +2709,6 @@ public partial class AiModelBuilder<T, TInput, TOutput>
             }
 
             episodeRewards.Add(episodeReward);
-            episodeLengths.Add(steps);
 
             // Calculate metrics for this episode
             var recentRewards = episodeRewards.Skip(Math.Max(0, episodeRewards.Count - 100)).Take(100).ToList();

--- a/src/Audio/Classification/AudioClassifierBase.cs
+++ b/src/Audio/Classification/AudioClassifierBase.cs
@@ -229,13 +229,13 @@ public abstract class AudioClassifierBase<T> : AudioNeuralNetworkBase<T>,
             if (count > 0)
             {
                 // Inverse frequency weighting
-                double weight = (double)totalSamples / (numClasses * count);
+                double weight = (double)totalSamples / ((double)numClasses * count);
                 weights[label] = NumOps.FromDouble(weight);
             }
             else
             {
                 // Assign maximum weight to classes with zero samples (they need the most attention)
-                double maxWeight = nonZeroCounts.Max(kvp => (double)totalSamples / (numClasses * kvp.Value));
+                double maxWeight = nonZeroCounts.Max(kvp => (double)totalSamples / ((double)numClasses * kvp.Value));
                 weights[label] = NumOps.FromDouble(maxWeight);
             }
         }

--- a/src/Audio/MusicAnalysis/BeatTracker.cs
+++ b/src/Audio/MusicAnalysis/BeatTracker.cs
@@ -170,8 +170,8 @@ public class BeatTracker<T> : MusicAnalysisBase<T>
     private double EstimateTempoFromEnvelope(double[] onsetEnvelope)
     {
         // Compute autocorrelation of onset envelope
-        int maxLag = (int)(_options.SampleRate / _options.HopLength * 60.0 / _options.MinTempo);
-        int minLag = (int)(_options.SampleRate / _options.HopLength * 60.0 / _options.MaxTempo);
+        int maxLag = (int)(_options.SampleRate / (double)_options.HopLength * 60.0 / _options.MinTempo);
+        int minLag = (int)(_options.SampleRate / (double)_options.HopLength * 60.0 / _options.MaxTempo);
 
         var autocorr = new double[maxLag];
         double maxCorr = 0;

--- a/src/Audio/Speaker/CAMPlusPlus.cs
+++ b/src/Audio/Speaker/CAMPlusPlus.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -51,7 +50,6 @@ public partial class CAMPlusPlus<T> : SpeakerRecognitionBase<T>, ISpeakerVerifie
     private readonly CAMPlusPlusOptions _options;
     public override ModelOptions GetOptions() => _options;
     private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
-    private readonly ConcurrentDictionary<string, SpeakerProfile<T>> _enrolledSpeakers;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -79,7 +77,6 @@ public partial class CAMPlusPlus<T> : SpeakerRecognitionBase<T>, ISpeakerVerifie
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
         _options.ModelPath = modelPath;
         OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 
@@ -93,7 +90,6 @@ public partial class CAMPlusPlus<T> : SpeakerRecognitionBase<T>, ISpeakerVerifie
         base.SampleRate = _options.SampleRate;
         EmbeddingDimension = _options.EmbeddingDim;
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 

--- a/src/Audio/Speaker/ECAPATDNNSpeaker.cs
+++ b/src/Audio/Speaker/ECAPATDNNSpeaker.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -52,7 +51,6 @@ public partial class ECAPATDNNSpeaker<T> : SpeakerRecognitionBase<T>, ISpeakerVe
     private readonly ECAPATDNNSpeakerOptions _options;
     public override ModelOptions GetOptions() => _options;
     private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
-    private readonly ConcurrentDictionary<string, SpeakerProfile<T>> _enrolledSpeakers;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -86,7 +84,6 @@ public partial class ECAPATDNNSpeaker<T> : SpeakerRecognitionBase<T>, ISpeakerVe
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
         _options.ModelPath = modelPath;
         OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 
@@ -106,7 +103,6 @@ public partial class ECAPATDNNSpeaker<T> : SpeakerRecognitionBase<T>, ISpeakerVe
         base.SampleRate = _options.SampleRate;
         EmbeddingDimension = _options.EmbeddingDim;
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 

--- a/src/Audio/Speaker/TitaNet.cs
+++ b/src/Audio/Speaker/TitaNet.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -50,7 +49,6 @@ public partial class TitaNet<T> : SpeakerRecognitionBase<T>, ISpeakerVerifier<T>
     private readonly TitaNetOptions _options;
     public override ModelOptions GetOptions() => _options;
     private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
-    private readonly ConcurrentDictionary<string, SpeakerProfile<T>> _enrolledSpeakers;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -81,7 +79,6 @@ public partial class TitaNet<T> : SpeakerRecognitionBase<T>, ISpeakerVerifier<T>
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
         _options.ModelPath = modelPath;
         OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 
@@ -98,7 +95,6 @@ public partial class TitaNet<T> : SpeakerRecognitionBase<T>, ISpeakerVerifier<T>
         base.SampleRate = _options.SampleRate;
         EmbeddingDimension = _options.EmbeddingDim;
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 

--- a/src/Audio/Speaker/WavLMSpeaker.cs
+++ b/src/Audio/Speaker/WavLMSpeaker.cs
@@ -1,4 +1,3 @@
-using System.Collections.Concurrent;
 using AiDotNet.Attributes;
 using AiDotNet.Enums;
 using AiDotNet.Helpers;
@@ -51,7 +50,6 @@ public partial class WavLMSpeaker<T> : SpeakerRecognitionBase<T>, ISpeakerVerifi
     private readonly WavLMSpeakerOptions _options;
     public override ModelOptions GetOptions() => _options;
     private IGradientBasedOptimizer<T, Tensor<T>, Tensor<T>>? _optimizer;
-    private readonly ConcurrentDictionary<string, SpeakerProfile<T>> _enrolledSpeakers;
     private bool _useNativeMode;
     private bool _disposed;
 
@@ -79,7 +77,6 @@ public partial class WavLMSpeaker<T> : SpeakerRecognitionBase<T>, ISpeakerVerifi
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
         _options.ModelPath = modelPath;
         OnnxEncoder = new OnnxModel<T>(modelPath, _options.OnnxOptions);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 
@@ -93,7 +90,6 @@ public partial class WavLMSpeaker<T> : SpeakerRecognitionBase<T>, ISpeakerVerifi
         base.SampleRate = _options.SampleRate;
         EmbeddingDimension = _options.EmbeddingDim;
         DefaultThreshold = NumOps.FromDouble(_options.DefaultThreshold);
-        _enrolledSpeakers = new ConcurrentDictionary<string, SpeakerProfile<T>>();
         InitializeLayers();
     }
 

--- a/src/AutoML/NAS/HardwareCostModel.cs
+++ b/src/AutoML/NAS/HardwareCostModel.cs
@@ -43,7 +43,6 @@ namespace AiDotNet.AutoML.NAS
         private readonly HardwarePlatform _platform;
         private readonly PlatformCharacteristics _characteristics;
         private readonly Dictionary<string, double> _calibrationFactors;
-        private readonly HashSet<string> _unknownOperations;
 
         /// <summary>
         /// Gets the target hardware platform.
@@ -61,7 +60,6 @@ namespace AiDotNet.AutoML.NAS
             _platform = platform;
             _characteristics = GetPlatformCharacteristics(platform);
             _calibrationFactors = new Dictionary<string, double>(StringComparer.OrdinalIgnoreCase);
-            _unknownOperations = new HashSet<string>(StringComparer.Ordinal);
         }
 
         /// <summary>

--- a/src/CausalDiscovery/Functional/RCDAlgorithm.cs
+++ b/src/CausalDiscovery/Functional/RCDAlgorithm.cs
@@ -134,7 +134,6 @@ public class RCDAlgorithm<T> : FunctionalBase<T>
 
         var W = new Matrix<T>(d, d);
         var remaining = new List<int>(Enumerable.Range(0, d));
-        var ordering = new List<int>();
 
         // Iteratively identify exogenous variables
         int maxRounds = d;
@@ -219,7 +218,6 @@ public class RCDAlgorithm<T> : FunctionalBase<T>
             }
 
             // Record causal coefficients from the identified exogenous variable to remaining ones
-            ordering.Add(bestVar);
             remaining.Remove(bestVar);
 
             foreach (int target in remaining)

--- a/src/CausalDiscovery/TimeSeries/NTSNOTEARSAlgorithm.cs
+++ b/src/CausalDiscovery/TimeSeries/NTSNOTEARSAlgorithm.cs
@@ -97,7 +97,6 @@ public class NTSNOTEARSAlgorithm<T> : TimeSeriesCausalBase<T>
 
         // Phase 2: Learn structure for each segment
         var segmentGraphs = new List<Matrix<T>>();
-        var segmentLengths = new List<int>();
 
         int prevEnd = 0;
         for (int seg = 0; seg <= changePoints.Count; seg++)
@@ -116,7 +115,6 @@ public class NTSNOTEARSAlgorithm<T> : TimeSeriesCausalBase<T>
                 // Learn structure for this segment using DYNOTEARS
                 var segGraph = LearnSegmentStructure(segData, segLen, d);
                 segmentGraphs.Add(segGraph);
-                segmentLengths.Add(segLen);
             }
 
             prevEnd = segEnd;

--- a/src/Classification/MultiLabel/MultiLabelClassifierBase.cs
+++ b/src/Classification/MultiLabel/MultiLabelClassifierBase.cs
@@ -619,7 +619,7 @@ public abstract partial class MultiLabelClassifierBase<T> : IMultiLabelClassifie
             }
         }
 
-        double avgGradient = parameters.Length > 0 ? totalGradient / (input.Rows * NumLabels * parameters.Length) : 0;
+        double avgGradient = parameters.Length > 0 ? totalGradient / ((double)input.Rows * NumLabels * parameters.Length) : 0;
         for (int i = 0; i < gradients.Length; i++)
         {
             gradients[i] = NumOps.FromDouble(avgGradient);

--- a/src/Clustering/AutoK/GMeans.cs
+++ b/src/Clustering/AutoK/GMeans.cs
@@ -360,7 +360,7 @@ public partial class GMeans<T> : ClusteringBase<T>
         double ad = -n - sum / n;
 
         // Apply correction for small samples
-        ad *= (1 + 4.0 / n - 25.0 / (n * n));
+        ad *= (1 + 4.0 / n - 25.0 / ((double)n * n));
 
         return ad;
     }

--- a/src/Clustering/AutoK/XMeans.cs
+++ b/src/Clustering/AutoK/XMeans.cs
@@ -401,7 +401,7 @@ public partial class XMeans<T> : ClusteringBase<T>
             }
         }
 
-        return NumOps.Divide(variance, NumOps.FromDouble(n * d));
+        return NumOps.Divide(variance, NumOps.FromDouble((double)n * d));
     }
 
     /// <inheritdoc />

--- a/src/Clustering/Evaluation/AdjustedRandIndex.cs
+++ b/src/Clustering/Evaluation/AdjustedRandIndex.cs
@@ -139,7 +139,7 @@ public class AdjustedRandIndex<T> : IExternalClusterMetric<T>
         }
 
         // Expected index
-        double expectedIndex = (double)(sumA * sumB) / totalPairs;
+        double expectedIndex = (double)sumA * sumB / totalPairs;
 
         // Max index
         double maxIndex = 0.5 * (sumA + sumB);

--- a/src/ComputerVision/Tracking/ByteTrack.cs
+++ b/src/ComputerVision/Tracking/ByteTrack.cs
@@ -40,7 +40,6 @@ public class ByteTrack<T> : ObjectTrackerBase<T>
 {
     private readonly List<STrack<T>> _trackedTracks;
     private readonly List<STrack<T>> _lostTracks;
-    private readonly List<STrack<T>> _removedTracks;
     private readonly double _trackHighThresh;
     private readonly double _trackLowThresh;
     private readonly double _newTrackThresh;
@@ -57,7 +56,6 @@ public class ByteTrack<T> : ObjectTrackerBase<T>
     {
         _trackedTracks = new List<STrack<T>>();
         _lostTracks = new List<STrack<T>>();
-        _removedTracks = new List<STrack<T>>();
 
         // ByteTrack specific thresholds
         _trackHighThresh = NumOps.ToDouble(options.ConfidenceThreshold);
@@ -290,7 +288,6 @@ public class ByteTrack<T> : ObjectTrackerBase<T>
             if (FrameCount - track.EndFrame > _trackBuffer)
             {
                 track.MarkRemoved();
-                _removedTracks.Add(track);
             }
             else
             {
@@ -340,7 +337,6 @@ public class ByteTrack<T> : ObjectTrackerBase<T>
         base.Reset();
         _trackedTracks.Clear();
         _lostTracks.Clear();
-        _removedTracks.Clear();
     }
 }
 

--- a/src/ComputerVision/Weights/WeightLoader.cs
+++ b/src/ComputerVision/Weights/WeightLoader.cs
@@ -61,8 +61,6 @@ public class WeightLoader
     /// </remarks>
     private Dictionary<string, Tensor<float>> LoadPyTorchWeights(string filePath)
     {
-        var weights = new Dictionary<string, Tensor<float>>();
-
         using var stream = File.OpenRead(filePath);
         using var reader = new BinaryReader(stream);
 

--- a/src/ContinualLearning/Trainers/EWCTrainer.cs
+++ b/src/ContinualLearning/Trainers/EWCTrainer.cs
@@ -174,7 +174,6 @@ public class EWCTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
 
         var lossHistory = new List<T>();
         var regLossHistory = new List<T>();
-        var validationLossHistory = new List<T>();
 
         var useReplay = _options.UseExperienceReplay ?? true;
         var replayLrFactor = _options.ReplayLearningRateFactor ?? 0.5;
@@ -305,7 +304,6 @@ public class EWCTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
             {
                 var valResult = EvaluateOnDataset(validationData);
                 validationLoss = valResult.Loss;
-                validationLossHistory.Add(valResult.Loss);
 
                 // Early stopping check
                 if (NumOps.Compare(valResult.Loss, bestValidationLoss) < 0)

--- a/src/ContinualLearning/Trainers/GEMTrainer.cs
+++ b/src/ContinualLearning/Trainers/GEMTrainer.cs
@@ -193,7 +193,6 @@ public class GEMTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
 
         var lossHistory = new List<T>();
         var constraintViolationHistory = new List<T>();
-        var validationLossHistory = new List<T>();
 
         var memoryStrength = _options.MemoryStrength ?? 0.5;
         var projectionMargin = _options.ProjectionMargin ?? 0.0;
@@ -323,7 +322,6 @@ public class GEMTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
             {
                 var valResult = EvaluateOnDataset(validationData);
                 validationLoss = valResult.Loss;
-                validationLossHistory.Add(valResult.Loss);
 
                 // Early stopping check
                 if (NumOps.Compare(valResult.Loss, bestValidationLoss) < 0)

--- a/src/ContinualLearning/Trainers/LwFTrainer.cs
+++ b/src/ContinualLearning/Trainers/LwFTrainer.cs
@@ -190,7 +190,6 @@ public class LwFTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
 
         var lossHistory = new List<T>();
         var distillationLossHistory = new List<T>();
-        var validationLossHistory = new List<T>();
 
         var useReplay = _options.UseExperienceReplay ?? true;
         var replayLrFactor = _options.ReplayLearningRateFactor ?? 0.5;
@@ -349,7 +348,6 @@ public class LwFTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
             {
                 var valResult = EvaluateOnDataset(validationData);
                 validationLoss = valResult.Loss;
-                validationLossHistory.Add(valResult.Loss);
 
                 // Early stopping check
                 if (NumOps.Compare(valResult.Loss, bestValidationLoss) < 0)

--- a/src/ContinualLearning/Trainers/MASTrainer.cs
+++ b/src/ContinualLearning/Trainers/MASTrainer.cs
@@ -197,7 +197,6 @@ public class MASTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
 
         var lossHistory = new List<T>();
         var regLossHistory = new List<T>();
-        var validationLossHistory = new List<T>();
 
         var useReplay = _options.UseExperienceReplay ?? true;
         var replayLrFactor = _options.ReplayLearningRateFactor ?? 0.5;
@@ -335,7 +334,6 @@ public class MASTrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TO
             {
                 var valResult = EvaluateOnDataset(validationData);
                 validationLoss = valResult.Loss;
-                validationLossHistory.Add(valResult.Loss);
 
                 // Early stopping check
                 if (NumOps.Compare(valResult.Loss, bestValidationLoss) < 0)

--- a/src/ContinualLearning/Trainers/SITrainer.cs
+++ b/src/ContinualLearning/Trainers/SITrainer.cs
@@ -191,7 +191,6 @@ public class SITrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TOu
 
         var lossHistory = new List<T>();
         var regLossHistory = new List<T>();
-        var validationLossHistory = new List<T>();
 
         var useReplay = _options.UseExperienceReplay ?? true;
         var replayLrFactor = _options.ReplayLearningRateFactor ?? 0.5;
@@ -345,7 +344,6 @@ public class SITrainer<T, TInput, TOutput> : ContinualLearnerBase<T, TInput, TOu
             {
                 var valResult = EvaluateOnDataset(validationData);
                 validationLoss = valResult.Loss;
-                validationLossHistory.Add(valResult.Loss);
 
                 // Early stopping check
                 if (NumOps.Compare(valResult.Loss, bestValidationLoss) < 0)

--- a/src/CrossValidators/GroupKFoldCrossValidator.cs
+++ b/src/CrossValidators/GroupKFoldCrossValidator.cs
@@ -125,7 +125,6 @@ public class GroupKFoldCrossValidator<T, TInput, TOutput> : CrossValidatorBase<T
         var groupIndices = uniqueGroups.Select(g => groups.Select((v, i) => (v, i)).Where(t => t.v == g).Select(t => t.i).ToArray()).ToArray();
 
         int numberOfFolds = Options.NumberOfFolds;
-        var folds = new List<int[]>();
 
         for (int i = 0; i < numberOfFolds; i++)
         {

--- a/src/DecompositionMethods/TimeSeriesDecomposition/AdditiveDecomposition.cs
+++ b/src/DecompositionMethods/TimeSeriesDecomposition/AdditiveDecomposition.cs
@@ -314,7 +314,7 @@ public class AdditiveDecomposition<T> : TimeSeriesDecompositionBase<T>
             for (int j = 0; j < n; j++)
             {
                 T distance = NumOps.Abs(NumOps.Subtract(data[j].x, data[i].x));
-                T weight = TriCube(NumOps.Divide(distance, NumOps.FromDouble(windowSize / 2)));
+                T weight = TriCube(NumOps.Divide(distance, NumOps.FromDouble(windowSize / 2.0)));
                 weightedPoints.Add((distance, weight, data[j].y));
             }
 

--- a/src/Diffusion/Schedulers/FlowMatchingScheduler.cs
+++ b/src/Diffusion/Schedulers/FlowMatchingScheduler.cs
@@ -128,13 +128,18 @@ public sealed partial class FlowMatchingScheduler<T> : NoiseSchedulerBase<T>
         for (int i = 0; i < inferenceSteps; i++)
         {
             int timestep = (int)Math.Round((Config.TrainTimesteps - 1) - i * stepSize);
+            // Keep the schedule strictly decreasing: when inferenceSteps == TrainTimesteps the step
+            // size drops below 1 and rounding would repeat a timestep (a zero-length Euler step).
+            if (timestepList.Count > 0)
+                timestep = Math.Min(timestep, timestepList[timestepList.Count - 1] - 1);
             timestep = Math.Max(0, Math.Min(timestep, Config.TrainTimesteps - 1));
             timestepList.Add(timestep);
         }
 
-        // Use reflection to set the private _timesteps field via the base class
-        // Instead, we call the base which sets it, then we'll compute sigmas
-        base.SetTimesteps(inferenceSteps);
+        // Install this linearly spaced schedule. The base SetTimesteps uses an integer stride
+        // (TrainTimesteps / inferenceSteps), which for non-divisor step counts stops well short of
+        // t = 0 (e.g. 600 of 1000 steps covered only timesteps 999..400) and would discard this list.
+        SetTimestepArray(timestepList.ToArray());
 
         // Compute sigmas for optional stochastic sampling
         _sigmas = ComputeSigmas(inferenceSteps);

--- a/src/Evaluation/Statistics/CochranQTest.cs
+++ b/src/Evaluation/Statistics/CochranQTest.cs
@@ -85,7 +85,7 @@ public class CochranQTest<T> : IClassifierComparisonTest<T>
         double sumRowSquares = rowTotals.Sum(r => (double)r * r);
         double sumRowTotals = rowTotals.Sum();
 
-        double numerator = (k - 1) * (k * sumColSquares - grandTotal * grandTotal);
+        double numerator = (k - 1) * (k * sumColSquares - (double)grandTotal * grandTotal);
         double denominator = k * sumRowTotals - sumRowSquares;
 
         if (Math.Abs(denominator) < 1e-10)

--- a/src/Evaluation/Statistics/DeLongTest.cs
+++ b/src/Evaluation/Statistics/DeLongTest.cs
@@ -142,7 +142,7 @@ public class DeLongTest<T> : IStatisticalTest<T>
                 else if (Math.Abs(posProb - negProb) < 1e-10) sum += 0.5;
             }
         }
-        return sum / (posIndices.Count * negIndices.Count);
+        return sum / ((double)posIndices.Count * negIndices.Count);
     }
 
     private double[] ComputeV10(T[] predictions, List<int> posIndices, List<int> negIndices)

--- a/src/Evaluation/Statistics/KruskalWallisTest.cs
+++ b/src/Evaluation/Statistics/KruskalWallisTest.cs
@@ -100,13 +100,13 @@ public class KruskalWallisTest<T> : IMultipleComparisonTest<T>
             sumRankSquaredOverN += (rankSums[g] * rankSums[g]) / groupSizes[g];
         }
 
-        double H = (12.0 / (N * (N + 1))) * sumRankSquaredOverN - 3 * (N + 1);
+        double H = (12.0 / ((double)N * (N + 1))) * sumRankSquaredOverN - 3 * (N + 1);
 
         // Tie correction
         var tieGroups = sorted.GroupBy(x => x.value).Where(g => g.Count() > 1).Select(g => g.Count()).ToList();
         if (tieGroups.Count > 0)
         {
-            double tieCorrection = 1 - tieGroups.Sum(t => (double)t * t * t - t) / (N * N * N - N);
+            double tieCorrection = 1 - tieGroups.Sum(t => (double)t * t * t - t) / ((double)N * N * N - N);
             if (tieCorrection > 1e-10)
                 H /= tieCorrection;
         }
@@ -183,7 +183,7 @@ public class KruskalWallisTest<T> : IMultipleComparisonTest<T>
             for (int j = i + 1; j < k; j++)
             {
                 double z = Math.Abs(meanRanks[i] - meanRanks[j]) /
-                          Math.Sqrt((N * (N + 1) / 12.0) * (1.0 / groupSizes[i] + 1.0 / groupSizes[j]));
+                          Math.Sqrt(((double)N * (N + 1) / 12.0) * (1.0 / groupSizes[i] + 1.0 / groupSizes[j]));
                 double pValue = 2 * (1 - NormalCDF(z));
                 results[(i, j)] = pValue;
             }

--- a/src/Evaluation/Statistics/WilcoxonSignedRankTest.cs
+++ b/src/Evaluation/Statistics/WilcoxonSignedRankTest.cs
@@ -97,8 +97,8 @@ public class WilcoxonSignedRankTest<T> : IPairedTest<T>
         double w = Math.Min(wPlus, wMinus);
 
         // For n >= 10, use normal approximation
-        double mean = nr * (nr + 1) / 4.0;
-        double std = Math.Sqrt(nr * (nr + 1) * (2 * nr + 1) / 24.0);
+        double mean = (double)nr * (nr + 1) / 4.0;
+        double std = Math.Sqrt((double)nr * (nr + 1) * (2.0 * nr + 1) / 24.0);
 
         // Continuity correction
         double z = (w - mean + 0.5) / std;
@@ -107,7 +107,7 @@ public class WilcoxonSignedRankTest<T> : IPairedTest<T>
         double pValue = 2 * NormalCdf(-Math.Abs(z));
 
         // Effect size: rank-biserial correlation
-        double effectSize = (wPlus - wMinus) / (nr * (nr + 1) / 2.0);
+        double effectSize = (wPlus - wMinus) / ((double)nr * (nr + 1) / 2.0);
 
         return new StatisticalTestResult<T>
         {

--- a/src/Finance/Forecasting/Neural/NHiTSFinance.cs
+++ b/src/Finance/Forecasting/Neural/NHiTSFinance.cs
@@ -549,7 +549,7 @@ public partial class NHiTSFinance<T> : ForecastingModelBase<T>
     /// <summary>
     /// Tape-aware average pooling. Trims the last-axis length to a
     /// multiple of <paramref name="kernelSize"/> via
-    /// <see cref="IEngine.TensorSliceAxis"/>, reshapes to pull out the
+    /// <see cref="IEngine.TensorNarrow"/>, reshapes to pull out the
     /// kernel dimension, and <see cref="IEngine.ReduceMean"/>s along
     /// it. Equivalent math to <see cref="ApplyPooling"/> — which uses
     /// <c>.Data.Span</c> loops and severs the gradient tape.
@@ -562,27 +562,22 @@ public partial class NHiTSFinance<T> : ForecastingModelBase<T>
         int batchSize = input.Shape[0];
         int seqLen = input.Shape.Length > 1 ? input.Shape[1] : input.Length / batchSize;
         int pooledLen = Math.Max(1, seqLen / kernelSize);
-        int keptLen = pooledLen * kernelSize;
+        // Same windows as ApplyPooling: when the sequence is shorter than the kernel, the single
+        // window averages the whole (shorter) sequence.
+        int windowLen = seqLen < kernelSize ? seqLen : kernelSize;
+        int keptLen = pooledLen * windowLen;
 
         var working = input;
         if (keptLen != seqLen)
         {
-            // Trim the trailing (seqLen % kernelSize) elements so the
-            // reshape splits cleanly. SliceAxis keeps the tape
-            // connected through the trim.
-            var slices = new List<Tensor<T>>();
-            for (int i = 0; i < keptLen; i++)
-                slices.Add(Engine.TensorSliceAxis(working, axis: 1, index: i));
-            // Re-stack into [batchSize, keptLen]. Using Reshape on a
-            // concatenated row would also work; staying with a loop of
-            // slices keeps the tape graph explicit.
-            throw new NotSupportedException(
-                $"N-HiTS tape pooling: seqLen ({seqLen}) must be a multiple of kernelSize ({kernelSize}). " +
-                "Pad the input upstream or configure _poolingKernelSizes so pooledLen*kernelSize covers the full window.");
+            // Trim the trailing (seqLen % kernelSize) elements so the reshape splits cleanly,
+            // exactly as ApplyPooling ignores the incomplete trailing window. TensorNarrow is
+            // tape-recorded, so the gradient scatters back to the kept positions.
+            working = Engine.TensorNarrow(working, 1, 0, keptLen);
         }
 
-        // Reshape [batch, seqLen] → [batch, pooledLen, kernelSize], mean over axis 2.
-        var reshaped = Engine.Reshape(working, new[] { batchSize, pooledLen, kernelSize });
+        // Reshape [batch, keptLen] → [batch, pooledLen, windowLen], mean over axis 2.
+        var reshaped = Engine.Reshape(working, new[] { batchSize, pooledLen, windowLen });
         var pooled = Engine.ReduceMean(reshaped, new[] { 2 }, keepDims: false);
         return pooled;
     }

--- a/src/Helpers/GraphModeDiagnostics.cs
+++ b/src/Helpers/GraphModeDiagnostics.cs
@@ -16,8 +16,6 @@ internal static class GraphModeDiagnostics
         Tensor<float> target,
         Action traceAction)
     {
-        var paramSet = new HashSet<object>(parameters.Select(p => (object)p));
-        paramSet.Add(input);
         var sb = new StringBuilder();
 
         using var scope = GraphMode.Enable();

--- a/src/Helpers/StatisticsHelper.cs
+++ b/src/Helpers/StatisticsHelper.cs
@@ -5842,8 +5842,8 @@ public static class StatisticsHelper<T>
         int n = x.Length;
         T numerator = _numOps.Subtract(_numOps.FromDouble(concordantPairs), _numOps.FromDouble(discordantPairs));
         T denominator = _numOps.Sqrt(_numOps.Multiply(
-            _numOps.FromDouble(n * (n - 1) / 2),
-            _numOps.FromDouble(n * (n - 1) / 2)
+            _numOps.FromDouble((double)n * (n - 1) / 2),
+            _numOps.FromDouble((double)n * (n - 1) / 2)
         ));
 
         return _numOps.Divide(numerator, denominator);

--- a/src/Kernels/StringKernel.cs
+++ b/src/Kernels/StringKernel.cs
@@ -183,7 +183,7 @@ public class StringKernel<T>
         {
             if (counts2.TryGetValue(kvp.Key, out int count2))
             {
-                dotProduct += kvp.Value * count2;
+                dotProduct += (double)kvp.Value * count2;
             }
         }
 
@@ -191,11 +191,11 @@ public class StringKernel<T>
         double norm1 = 0, norm2 = 0;
         foreach (var count in counts1.Values)
         {
-            norm1 += count * count;
+            norm1 += (double)count * count;
         }
         foreach (var count in counts2.Values)
         {
-            norm2 += count * count;
+            norm2 += (double)count * count;
         }
 
         norm1 = Math.Sqrt(norm1);
@@ -448,7 +448,7 @@ public class StringKernel<T>
         {
             if (words2.TryGetValue(kvp.Key, out int count2))
             {
-                dotProduct += kvp.Value * count2;
+                dotProduct += (double)kvp.Value * count2;
             }
         }
 
@@ -456,11 +456,11 @@ public class StringKernel<T>
         double norm1 = 0, norm2 = 0;
         foreach (var count in words1.Values)
         {
-            norm1 += count * count;
+            norm1 += (double)count * count;
         }
         foreach (var count in words2.Values)
         {
-            norm2 += count * count;
+            norm2 += (double)count * count;
         }
 
         norm1 = Math.Sqrt(norm1);

--- a/src/MetaLearning/Algorithms/BOILAlgorithm.cs
+++ b/src/MetaLearning/Algorithms/BOILAlgorithm.cs
@@ -607,7 +607,7 @@ public partial class BOILAlgorithm<T, TInput, TOutput> : MetaLearnerBase<T, TInp
 
         for (int s = 0; s < sampleCount; s++)
         {
-            int i = (int)(s * bodyParams.Length / (double)sampleCount);
+            int i = (int)((double)s * bodyParams.Length / sampleCount);
 
             // Skip if not in adaptation fraction
             double position = i / (double)bodyParams.Length;

--- a/src/MetaLearning/Algorithms/MatchingNetworksAlgorithm.cs
+++ b/src/MetaLearning/Algorithms/MatchingNetworksAlgorithm.cs
@@ -302,7 +302,7 @@ public partial class MatchingNetworksAlgorithm<T, TInput, TOutput> : MetaLearner
 
         for (int s = 0; s < sampleCount; s++)
         {
-            int i = (int)(s * parameters.Length / (double)sampleCount);
+            int i = (int)((double)s * parameters.Length / sampleCount);
 
             // Perturb parameter
             T original = parameters[i];

--- a/src/Metrics/KernelInceptionDistance.cs
+++ b/src/Metrics/KernelInceptionDistance.cs
@@ -252,7 +252,7 @@ public class KernelInceptionDistance<T>
                 k11 += 2.0 * k;
             }
         }
-        k11 /= (n1 * (n1 - 1));
+        k11 /= ((double)n1 * (n1 - 1));
 
         // E[k(y, y')] for y, y' from features2
         double k22 = 0.0;
@@ -265,7 +265,7 @@ public class KernelInceptionDistance<T>
                 k22 += 2.0 * k;
             }
         }
-        k22 /= (n2 * (n2 - 1));
+        k22 /= ((double)n2 * (n2 - 1));
 
         // E[k(x, y)] for x from features1, y from features2
         double k12 = 0.0;
@@ -278,7 +278,7 @@ public class KernelInceptionDistance<T>
                 k12 += k;
             }
         }
-        k12 /= (n1 * n2);
+        k12 /= ((double)n1 * n2);
 
         // MMD^2 = E[k(x,x')] + E[k(y,y')] - 2*E[k(x,y)]
         double mmdSquared = k11 + k22 - 2.0 * k12;

--- a/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
+++ b/src/NeuralNetworks/AudioVisualEventLocalizationNetwork.cs
@@ -1319,7 +1319,7 @@ public partial class AudioVisualEventLocalizationNetwork<T> : MultimodalModelLay
             }
         }
 
-        return _numOps.Divide(totalDiff, _numOps.FromDouble(frames.Count * frames[0].ToVector().Length));
+        return _numOps.Divide(totalDiff, _numOps.FromDouble((double)frames.Count * frames[0].ToVector().Length));
     }
 
     private Vector<T> EncodeTextDescription(string description)

--- a/src/NeuralNetworks/Genome.cs
+++ b/src/NeuralNetworks/Genome.cs
@@ -309,7 +309,28 @@ public class Genome<T>
 
         var nodeValues = new Dictionary<int, T>();
         var nodeActivations = new Dictionary<int, IActivationFunction<T>>();
+        var activatedNodes = new HashSet<int>();
         var processedNodes = new HashSet<int>();
+
+        // Every non-input node that receives weighted input (hidden or output) is squashed with the
+        // logistic sigmoid, the activation NEAT uses for those nodes. Input nodes pass their values
+        // through unchanged, as do source-only nodes the genome gives no incoming connection.
+        IActivationFunction<T> sigmoid = new AiDotNet.ActivationFunctions.SigmoidActivation<T>();
+        foreach (var conn in Connections)
+        {
+            if (conn.IsEnabled && conn.ToNode >= InputSize) nodeActivations[conn.ToNode] = sigmoid;
+        }
+
+        // Applies a node's activation exactly once. In topological order a node's weighted input
+        // is complete the first time it is used as a source, so hidden nodes are activated BEFORE
+        // their value propagates downstream (otherwise the non-linearity never reaches the outputs).
+        void ApplyActivation(int node)
+        {
+            if (nodeActivations.TryGetValue(node, out var activation) && activatedNodes.Add(node))
+            {
+                nodeValues[node] = activation.Activate(nodeValues[node]);
+            }
+        }
 
         // Initialize input nodes
         for (int i = 0; i < InputSize; i++)
@@ -338,19 +359,18 @@ public class Genome<T>
             if (!nodeValues.ContainsKey(conn.ToNode))
                 nodeValues[conn.ToNode] = NumOps.Zero;
 
+            ApplyActivation(conn.FromNode);
+
             var value = NumOps.Multiply(nodeValues[conn.FromNode], conn.Weight);
             nodeValues[conn.ToNode] = NumOps.Add(nodeValues[conn.ToNode], value);
 
             processedNodes.Add(conn.ToNode);
         }
 
-        // Apply activation functions to all processed nodes
+        // Apply activation functions to the remaining processed nodes (outputs and other sinks)
         foreach (var node in processedNodes)
         {
-            if (nodeActivations.TryGetValue(node, out var activation))
-            {
-                nodeValues[node] = activation.Activate(nodeValues[node]);
-            }
+            ApplyActivation(node);
         }
 
         // Collect output values

--- a/src/NeuralNetworks/Layers/EmbeddingLayer.cs
+++ b/src/NeuralNetworks/Layers/EmbeddingLayer.cs
@@ -853,7 +853,7 @@ public partial class EmbeddingLayer<T> : LayerBase<T>, IAuxiliaryLossLayer<T>, I
 
         // Average over all embedding values and scale by 0.5 (standard L2 regularization)
         int totalElements = vocabSize * embeddingDim;
-        T regularizationLoss = NumericalStabilityHelper.SafeDiv(sumSquaredNorms, NumOps.FromDouble(totalElements * 2));
+        T regularizationLoss = NumericalStabilityHelper.SafeDiv(sumSquaredNorms, NumOps.FromDouble(totalElements * 2.0));
 
         // Store unweighted loss for diagnostics
         _lastEmbeddingRegularizationLoss = regularizationLoss;

--- a/src/NeuralNetworks/Layers/SSM/RWKV7Block.cs
+++ b/src/NeuralNetworks/Layers/SSM/RWKV7Block.cs
@@ -805,10 +805,6 @@ public partial class RWKV7Block<T> : LayerBase<T>, IShapeContract
     /// </summary>
     private Tensor<T> TimeMixingForward(Tensor<T> x, int batchSize, int seqLen)
     {
-        // Per-step outputs are concatenated on the autodiff tape (end of loop) rather
-        // than written into a rented buffer via SafeSetSlice, which detached the output.
-        var outputSlices = new System.Collections.Generic.List<Tensor<T>>(seqLen);
-
         // State: [batch, numHeads, headDim, headDim] - matrix-valued per head.
         // Statefulness is for autoregressive streaming inference only; in training each
         // sequence is independent, so start from a fresh zero state every Forward (otherwise

--- a/src/NeuralNetworks/Layers/SSM/SSMQuantizationHelper.cs
+++ b/src/NeuralNetworks/Layers/SSM/SSMQuantizationHelper.cs
@@ -158,7 +158,7 @@ public static class SSMQuantizationHelper<T>
 
         int paramCount = checked((int)layer.ParameterCount);
         long originalBytes = paramCount * (long)Unsafe.SizeOf<T>();
-        long quantizedBytes = (long)Math.Ceiling(paramCount * targetBitWidth / 8.0);
+        long quantizedBytes = (long)Math.Ceiling((double)paramCount * targetBitWidth / 8.0);
 
         // Add overhead for scale/zero-point per group (if per-channel)
         int numGroups = Math.Max(1, paramCount / 128); // Assume group size 128

--- a/src/NeuralNetworks/NEAT.cs
+++ b/src/NeuralNetworks/NEAT.cs
@@ -1264,16 +1264,10 @@ public partial class NEAT<T> : VectorModelLayoutBase<T>
         // Create a dictionary to track nodes that feed into each node
         var incomingConnections = new Dictionary<int, List<Connection<T>>>();
 
-        // Create a set of all nodes
-        var allNodes = new HashSet<int>();
-
-        // Populate incoming connections and collect all nodes
+        // Populate incoming connections
         foreach (var conn in genome.Connections)
         {
             if (!conn.IsEnabled) continue;
-
-            allNodes.Add(conn.FromNode);
-            allNodes.Add(conn.ToNode);
 
             if (!incomingConnections.ContainsKey(conn.ToNode))
             {

--- a/src/NeuralNetworks/SyntheticData/TabLLMGenGenerator.cs
+++ b/src/NeuralNetworks/SyntheticData/TabLLMGenGenerator.cs
@@ -504,7 +504,6 @@ public partial class TabLLMGenGenerator<T> : NeuralSyntheticTabularGeneratorBase
         int schemaTokens = _options.SchemaTokensPerColumn;
         var result = new Vector<T>(_columns.Count);
 
-        var generatedTokens = new List<int>();
         var generatedEmbeddings = new List<Vector<T>>();
 
         int valueTokenBase = _specialTokenOffset + _columns.Count * schemaTokens;
@@ -516,7 +515,6 @@ public partial class TabLLMGenGenerator<T> : NeuralSyntheticTabularGeneratorBase
             for (int s = 0; s < schemaTokens; s++)
             {
                 int token = schemaBase + s;
-                generatedTokens.Add(token);
                 generatedEmbeddings.Add(EmbedToken(token));
             }
 
@@ -532,7 +530,6 @@ public partial class TabLLMGenGenerator<T> : NeuralSyntheticTabularGeneratorBase
                 int valueToken = SampleFromLogits(logits, valueTokenBase, _colVocabSizes[c]);
                 int relativeToken = valueToken - valueTokenBase;
 
-                generatedTokens.Add(valueToken);
                 generatedEmbeddings.Add(EmbedToken(valueToken));
 
                 result[c] = NumOps.FromDouble(DetokenizeValue(relativeToken, c));

--- a/src/PhysicsInformed/PINNs/MultiScalePINN.cs
+++ b/src/PhysicsInformed/PINNs/MultiScalePINN.cs
@@ -441,7 +441,8 @@ namespace AiDotNet.PhysicsInformed.PINNs
                 UpdateAllScaleNetworks();
             }
 
-            return NumOps.Divide(totalLoss, NumOps.FromDouble(numPoints / batchSize));
+            // Average over the number of batches actually processed (the last one may be partial).
+            return NumOps.Divide(totalLoss, NumOps.FromDouble(Math.Ceiling((double)numPoints / batchSize)));
         }
 
         /// <summary>

--- a/src/Preprocessing/DataPreparation/Splitting/Specialized/OutOfDistributionSplitter.cs
+++ b/src/Preprocessing/DataPreparation/Splitting/Specialized/OutOfDistributionSplitter.cs
@@ -118,7 +118,6 @@ public class OutOfDistributionSplitter<T> : DataSplitterBase<T>
 
         // OOD samples go to test, others can go to either based on testSize
         int oodCount = (int)((1 - _oodPercentile) * nSamples);
-        var oodIndices = new HashSet<int>(sortedIndices.Take(oodCount));
 
         var testIndices = new List<int>();
         var trainIndices = new List<int>();

--- a/src/Preprocessing/DimensionalityReduction/SparsePCA.cs
+++ b/src/Preprocessing/DimensionalityReduction/SparsePCA.cs
@@ -377,7 +377,7 @@ public class SparsePCA<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 error += diff * diff;
             }
         }
-        return error / (n * p);
+        return error / ((double)n * p);
     }
 
     private static double[,] InvertMatrix(double[,] matrix, int n)

--- a/src/Preprocessing/Document/Binarization.cs
+++ b/src/Preprocessing/Document/Binarization.cs
@@ -102,7 +102,7 @@ public class Binarization<T> : IDisposable
         int total = gray.Length;
         double sum = 0;
         for (int i = 0; i < 256; i++)
-            sum += i * histogram[i];
+            sum += (double)i * histogram[i];
 
         double sumB = 0;
         int wB = 0;
@@ -117,12 +117,12 @@ public class Binarization<T> : IDisposable
             int wF = total - wB;
             if (wF == 0) break;
 
-            sumB += t * histogram[t];
+            sumB += (double)t * histogram[t];
 
             double mB = sumB / wB;
             double mF = (sum - sumB) / wF;
 
-            double variance = wB * wF * (mB - mF) * (mB - mF);
+            double variance = (double)wB * wF * (mB - mF) * (mB - mF);
 
             if (variance > maxVariance)
             {

--- a/src/Preprocessing/FeatureSelection/Filter/Correlation/DistanceCorrelation.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Correlation/DistanceCorrelation.cs
@@ -160,7 +160,7 @@ public class DistanceCorrelation<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
         for (int i = 0; i < n; i++)
             for (int j = 0; j < n; j++)
                 sum += a[i, j] * b[i, j];
-        return sum / (n * n);
+        return sum / ((double)n * n);
     }
 
     public Matrix<T> FitTransform(Matrix<T> data, Vector<T> target)

--- a/src/Preprocessing/FeatureSelection/Filter/Correlation/PointBiserial.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Correlation/PointBiserial.cs
@@ -109,7 +109,7 @@ public class PointBiserial<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 continue;
             }
 
-            double pq = (double)(n0 * n1) / (n * n);
+            double pq = (double)n0 * n1 / ((double)n * n);
             _correlations[j] = Math.Abs((mean1 - mean0) / stdTotal * Math.Sqrt(pq));
         }
 

--- a/src/Preprocessing/FeatureSelection/Filter/DistanceCorrelation.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/DistanceCorrelation.cs
@@ -159,7 +159,7 @@ public class DistanceCorrelation<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             rowMeans[i] /= n;
             colMeans[i] /= n;
         }
-        grandMean /= (n * n);
+        grandMean /= ((double)n * n);
 
         // Double centering
         for (int i = 0; i < n; i++)
@@ -176,7 +176,7 @@ public class DistanceCorrelation<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             for (int k = 0; k < n; k++)
                 sum += a[i, k] * b[i, k];
 
-        return sum / (n * n);
+        return sum / ((double)n * n);
     }
 
     public Matrix<T> FitTransform(Matrix<T> data, Vector<T> target)

--- a/src/Preprocessing/FeatureSelection/Filter/InformationTheory/AdjustedMutualInformation.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/InformationTheory/AdjustedMutualInformation.cs
@@ -201,7 +201,7 @@ public class AdjustedMutualInformation<T> : TransformerBase<T, Matrix<T>, Matrix
 
                 for (int nij = minNij; nij <= maxNij; nij++)
                 {
-                    double term = (double)nij / n * Math.Log((double)n * nij / (ai * bj));
+                    double term = (double)nij / n * Math.Log((double)n * nij / ((double)ai * bj));
                     double hyperProb = HypergeometricPMF(nij, ai, bj, n);
                     emi += term * hyperProb;
                 }

--- a/src/Preprocessing/FeatureSelection/Filter/Relief/MultiSURF.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Relief/MultiSURF.cs
@@ -136,7 +136,7 @@ public class MultiSURF<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 {
                     double hit_val = NumOps.ToDouble(data[hitIdx, j]);
                     double diffHit = Math.Abs(ri_val - hit_val) / range;
-                    _featureWeights[j] -= diffHit / (n * Math.Max(1, nearHits.Count));
+                    _featureWeights[j] -= diffHit / ((double)n * Math.Max(1, nearHits.Count));
                 }
 
                 // Contribution from misses
@@ -144,7 +144,7 @@ public class MultiSURF<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 {
                     double miss_val = NumOps.ToDouble(data[missIdx, j]);
                     double diffMiss = Math.Abs(ri_val - miss_val) / range;
-                    _featureWeights[j] += diffMiss / (n * Math.Max(1, nearMisses.Count));
+                    _featureWeights[j] += diffMiss / ((double)n * Math.Max(1, nearMisses.Count));
                 }
             }
         }

--- a/src/Preprocessing/FeatureSelection/Filter/Relief/SURF.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Relief/SURF.cs
@@ -120,7 +120,7 @@ public class SURF<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 for (int j = 0; j < p; j++)
                 {
                     double diff = Diff(data, i, hitIdx, j, featureRanges[j]);
-                    _featureWeights[j] -= diff / (n * Math.Max(1, nearHits.Count));
+                    _featureWeights[j] -= diff / ((double)n * Math.Max(1, nearHits.Count));
                 }
             }
 
@@ -129,7 +129,7 @@ public class SURF<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 for (int j = 0; j < p; j++)
                 {
                     double diff = Diff(data, i, missIdx, j, featureRanges[j]);
-                    _featureWeights[j] += diff / (n * Math.Max(1, nearMisses.Count));
+                    _featureWeights[j] += diff / ((double)n * Math.Max(1, nearMisses.Count));
                 }
             }
         }

--- a/src/Preprocessing/FeatureSelection/Filter/Statistical/KruskalWallis.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Statistical/KruskalWallis.cs
@@ -118,7 +118,7 @@ public class KruskalWallis<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             for (int g = 0; g < numGroups; g++)
                 sumSquaredRankSums += rankSums[g] * rankSums[g] / groupSizes[g];
 
-            double H = 12.0 / (n * (n + 1)) * sumSquaredRankSums - 3 * (n + 1);
+            double H = 12.0 / ((double)n * (n + 1)) * sumSquaredRankSums - 3 * (n + 1);
 
             // Tie correction
             // (simplified - full correction would count ties)

--- a/src/Preprocessing/FeatureSelection/Filter/Statistical/WilcoxonSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Statistical/WilcoxonSelector.cs
@@ -89,10 +89,10 @@ public class WilcoxonSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             double r0 = class0.Sum(i => ranked[i]);
 
             // U statistic for class 0
-            double u0 = r0 - (n0 * (n0 + 1)) / 2.0;
+            double u0 = r0 - ((double)n0 * (n0 + 1)) / 2.0;
 
             // Normalize U to [0, 1]
-            double maxU = n0 * n1;
+            double maxU = (double)n0 * n1;
             _uStatistics[j] = maxU > 0 ? Math.Abs(u0 - maxU / 2) / (maxU / 2) : 0;
         }
 

--- a/src/Preprocessing/FeatureSelection/Filter/Statistical/WilcoxonSignedRank.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Statistical/WilcoxonSignedRank.cs
@@ -121,8 +121,8 @@ public class WilcoxonSignedRank<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
 
             // Normal approximation for p-value
             int nPairs = differences.Count;
-            double mean = nPairs * (nPairs + 1) / 4.0;
-            double stdDev = Math.Sqrt(nPairs * (nPairs + 1) * (2 * nPairs + 1) / 24.0);
+            double mean = (double)nPairs * (nPairs + 1) / 4.0;
+            double stdDev = Math.Sqrt((double)nPairs * (nPairs + 1) * (2 * nPairs + 1) / 24.0);
 
             if (stdDev > 0)
             {

--- a/src/Preprocessing/FeatureSelection/Filter/Univariate/FisherExactTest.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Univariate/FisherExactTest.cs
@@ -110,7 +110,7 @@ public class FisherExactTest<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             _pValues[j] = FisherExactP(a, b, c, d);
 
             // Odds ratio
-            _oddsRatios[j] = (b * c) > 0 ? (double)(a * d) / (b * c) : double.PositiveInfinity;
+            _oddsRatios[j] = b > 0 && c > 0 ? (double)a * d / ((double)b * c) : double.PositiveInfinity;
         }
 
         int nToSelect = Math.Min(_nFeaturesToSelect, p);

--- a/src/Preprocessing/FeatureSelection/Filter/Univariate/KruskalWallis.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Univariate/KruskalWallis.cs
@@ -127,7 +127,7 @@ public class KruskalWallis<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 sumTerm += (Ri * Ri) / ni;
             }
 
-            _hStatistics[j] = (12.0 / (n * (n + 1))) * sumTerm - 3 * (n + 1);
+            _hStatistics[j] = (12.0 / ((double)n * (n + 1))) * sumTerm - 3 * (n + 1);
 
             // Tie correction (optional for large samples)
             // For simplicity, we skip the exact tie correction

--- a/src/Preprocessing/FeatureSelection/Filter/Univariate/KruskalWallisH.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Univariate/KruskalWallisH.cs
@@ -132,7 +132,7 @@ public class KruskalWallisH<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                     h += groupCounts[g] * Math.Pow(meanRank - (n + 1) / 2.0, 2);
                 }
             }
-            h *= 12.0 / (n * (n + 1));
+            h *= 12.0 / ((double)n * (n + 1));
 
             _hStatistics[j] = h;
 

--- a/src/Preprocessing/FeatureSelection/Filter/Univariate/KruskalWallisTest.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Univariate/KruskalWallisTest.cs
@@ -118,7 +118,7 @@ public class KruskalWallisTest<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 sumRankSq += (groupRankSum * groupRankSum) / group.Count;
             }
 
-            double H = (12.0 / (n * (n + 1))) * sumRankSq - 3 * (n + 1);
+            double H = (12.0 / ((double)n * (n + 1))) * sumRankSq - 3 * (n + 1);
 
             // Tie correction
             var tieGroups = new Dictionary<double, int>();
@@ -132,10 +132,10 @@ public class KruskalWallisTest<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
 
             double tieCorrection = 0;
             foreach (var count in tieGroups.Values.Where(c => c > 1))
-                tieCorrection += count * count * count - count;
+                tieCorrection += (double)count * count * count - count;
 
             if (tieCorrection > 0)
-                H /= (1 - tieCorrection / (n * n * n - n));
+                H /= (1 - tieCorrection / ((double)n * n * n - n));
 
             _hStatistics[j] = H;
 

--- a/src/Preprocessing/FeatureSelection/Filter/Univariate/WilcoxonSignedRank.cs
+++ b/src/Preprocessing/FeatureSelection/Filter/Univariate/WilcoxonSignedRank.cs
@@ -117,8 +117,8 @@ public class WilcoxonSignedRank<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
 
             // Normal approximation for p-value
             int nPairs = ranked.Count;
-            double mu = nPairs * (nPairs + 1) / 4.0;
-            double sigma = Math.Sqrt(nPairs * (nPairs + 1) * (2 * nPairs + 1) / 24.0);
+            double mu = (double)nPairs * (nPairs + 1) / 4.0;
+            double sigma = Math.Sqrt((double)nPairs * (nPairs + 1) * (2 * nPairs + 1) / 24.0);
 
             if (sigma > 1e-10)
             {

--- a/src/Preprocessing/FeatureSelection/Kernel/HSICSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Kernel/HSICSelector.cs
@@ -121,7 +121,7 @@ public class HSICSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             for (int i = 0; i < n; i++)
                 for (int j = 0; j < n; j++)
                     hsic += HKxH[i, j] * HKyH[j, i];
-            hsic /= ((n - 1) * (n - 1));
+            hsic /= ((double)(n - 1) * (n - 1));
 
             _hsicScores[feat] = Math.Max(0, hsic);
         }

--- a/src/Preprocessing/FeatureSelection/Kernel/KernelPCASelector.cs
+++ b/src/Preprocessing/FeatureSelection/Kernel/KernelPCASelector.cs
@@ -96,7 +96,7 @@ public class KernelPCASelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             rowMeans[i] /= n;
         }
         for (int j = 0; j < n; j++) colMeans[j] /= n;
-        totalMean /= (n * n);
+        totalMean /= ((double)n * n);
 
         var Kc = new double[n, n];
         for (int i = 0; i < n; i++)
@@ -123,7 +123,7 @@ public class KernelPCASelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                         sensitivity += Math.Abs(eigenvectors[i, k] * eigenvectors[i2, k] * diff * diff);
                     }
                 }
-                _featureImportances[j] += sensitivity / (n * n);
+                _featureImportances[j] += sensitivity / ((double)n * n);
             }
         }
 

--- a/src/Preprocessing/FeatureSelection/Kernel/MMDBasedSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Kernel/MMDBasedSelector.cs
@@ -133,7 +133,7 @@ public class MMDBasedSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 kXX += Math.Exp(-_gamma * diff * diff);
             }
         }
-        kXX /= (n1 * n1);
+        kXX /= ((double)n1 * n1);
 
         // E[k(Y, Y')]
         double kYY = 0;
@@ -145,7 +145,7 @@ public class MMDBasedSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 kYY += Math.Exp(-_gamma * diff * diff);
             }
         }
-        kYY /= (n2 * n2);
+        kYY /= ((double)n2 * n2);
 
         // E[k(X, Y)]
         double kXY = 0;
@@ -157,7 +157,7 @@ public class MMDBasedSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 kXY += Math.Exp(-_gamma * diff * diff);
             }
         }
-        kXY /= (n1 * n2);
+        kXY /= ((double)n1 * n2);
 
         // MMD^2 = E[k(X,X')] + E[k(Y,Y')] - 2*E[k(X,Y)]
         double mmdSquared = kXX + kYY - 2 * kXY;

--- a/src/Preprocessing/FeatureSelection/Moment/BimodalitySelector.cs
+++ b/src/Preprocessing/FeatureSelection/Moment/BimodalitySelector.cs
@@ -90,7 +90,7 @@ public class BimodalitySelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             // Bimodality coefficient (Sarle's formula)
             // BC = (skewness² + 1) / (kurtosis + 3 × (n-1)²/((n-2)(n-3)))
             double skewSquared = skewness * skewness;
-            double sampleCorrection = 3.0 * (n - 1) * (n - 1) / ((n - 2) * (n - 3));
+            double sampleCorrection = 3.0 * (n - 1) * (n - 1) / ((double)(n - 2) * (n - 3));
             double denominator = kurtosis + sampleCorrection;
 
             // Avoid division by zero or negative

--- a/src/Preprocessing/FeatureSelection/Nonlinear/DistanceCorrelationSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Nonlinear/DistanceCorrelationSelector.cs
@@ -97,7 +97,7 @@ public class DistanceCorrelationSelector<T> : TransformerBase<T, Matrix<T>, Matr
             for (int i1 = 0; i1 < n; i1++)
                 for (int i2 = 0; i2 < n; i2++)
                     dcov += xCentered[i1, i2] * yCentered[i1, i2];
-            dcov = Math.Sqrt(dcov / (n * n));
+            dcov = Math.Sqrt(dcov / ((double)n * n));
 
             // Distance correlation
             _dcorValues[j] = dcov / Math.Sqrt(Math.Sqrt(xVar * yVar));
@@ -144,7 +144,7 @@ public class DistanceCorrelationSelector<T> : TransformerBase<T, Matrix<T>, Matr
         }
         for (int j = 0; j < n; j++)
             colMeans[j] /= n;
-        grandMean /= (n * n);
+        grandMean /= ((double)n * n);
 
         for (int i = 0; i < n; i++)
             for (int j = 0; j < n; j++)
@@ -160,7 +160,7 @@ public class DistanceCorrelationSelector<T> : TransformerBase<T, Matrix<T>, Matr
         for (int i = 0; i < n; i++)
             for (int j = 0; j < n; j++)
                 sum += centered[i, j] * centered[i, j];
-        return sum / (n * n);
+        return sum / ((double)n * n);
     }
 
     public Matrix<T> FitTransform(Matrix<T> data, Vector<T> target)

--- a/src/Preprocessing/FeatureSelection/Nonlinear/HilbertSchmidtSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Nonlinear/HilbertSchmidtSelector.cs
@@ -100,7 +100,7 @@ public class HilbertSchmidtSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>
             for (int i = 0; i < n; i++)
                 for (int k = 0; k < n; k++)
                     hsic += KxC[i, k] * KyC[k, i];
-            hsic /= (n * n);
+            hsic /= ((double)n * n);
 
             _hsicValues[j] = Math.Max(0, hsic);
         }
@@ -172,7 +172,7 @@ public class HilbertSchmidtSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>
             }
             rowMeans[i] /= n;
         }
-        grandMean /= (n * n);
+        grandMean /= ((double)n * n);
 
         for (int i = 0; i < n; i++)
             for (int j = 0; j < n; j++)

--- a/src/Preprocessing/FeatureSelection/Nonparametric/DistanceCorrelationSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Nonparametric/DistanceCorrelationSelector.cs
@@ -133,7 +133,7 @@ public class DistanceCorrelationSelector<T> : TransformerBase<T, Matrix<T>, Matr
             rowMeans[i] /= n;
             colMeans[i] /= n;
         }
-        grandMean /= (n * n);
+        grandMean /= ((double)n * n);
 
         // Double centering
         for (int i = 0; i < n; i++)
@@ -161,9 +161,9 @@ public class DistanceCorrelationSelector<T> : TransformerBase<T, Matrix<T>, Matr
             }
         }
 
-        dcovXY /= (n * n);
-        dcovXX /= (n * n);
-        dcovYY /= (n * n);
+        dcovXY /= ((double)n * n);
+        dcovXX /= ((double)n * n);
+        dcovYY /= ((double)n * n);
 
         double denom = Math.Sqrt(dcovXX) * Math.Sqrt(dcovYY);
         return denom > 1e-10 ? Math.Sqrt(Math.Max(0, dcovXY)) / Math.Sqrt(denom) : 0;

--- a/src/Preprocessing/FeatureSelection/Statistical/DistanceCorrelationSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Statistical/DistanceCorrelationSelector.cs
@@ -149,9 +149,9 @@ public class DistanceCorrelationSelector<T> : TransformerBase<T, Matrix<T>, Matr
             }
         }
 
-        dCovSq /= n * n;
-        dVarASq /= n * n;
-        dVarBSq /= n * n;
+        dCovSq /= (double)n * n;
+        dVarASq /= (double)n * n;
+        dVarBSq /= (double)n * n;
 
         if (dVarASq < 1e-10 || dVarBSq < 1e-10) return 0;
 

--- a/src/Preprocessing/FeatureSelection/Statistical/PointBiserialSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Statistical/PointBiserialSelector.cs
@@ -106,7 +106,7 @@ public class PointBiserialSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             double std = Math.Sqrt(variance) + 1e-10;
 
             // Point-biserial correlation
-            _correlationScores[j] = Math.Abs((mean1 - mean0) / std * Math.Sqrt((double)n0 * n1 / (n * n)));
+            _correlationScores[j] = Math.Abs((mean1 - mean0) / std * Math.Sqrt((double)n0 * n1 / ((double)n * n)));
         }
 
         int numToSelect = Math.Min(_nFeaturesToSelect, p);

--- a/src/Preprocessing/FeatureSelection/Supervised/KruskalWallisSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Supervised/KruskalWallisSelector.cs
@@ -118,7 +118,7 @@ public class KruskalWallisSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 if (classCounts[c] > 0)
                     H += rankSums[c] * rankSums[c] / classCounts[c];
             }
-            H = 12.0 / (n * (n + 1)) * H - 3 * (n + 1);
+            H = 12.0 / ((double)n * (n + 1)) * H - 3 * (n + 1);
 
             // Tie correction (simplified)
             _hStatistics[j] = H;

--- a/src/Preprocessing/FeatureSelection/Supervised/WilcoxonSelector.cs
+++ b/src/Preprocessing/FeatureSelection/Supervised/WilcoxonSelector.cs
@@ -115,8 +115,8 @@ public class WilcoxonSelector<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
             double U = Math.Min(U1, U0);
 
             // Standardized statistic (approximate normal for large samples)
-            double meanU = n0 * n1 / 2.0;
-            double stdU = Math.Sqrt(n0 * n1 * (n0 + n1 + 1.0) / 12);
+            double meanU = (double)n0 * n1 / 2.0;
+            double stdU = Math.Sqrt((double)n0 * n1 * (n0 + n1 + 1.0) / 12);
 
             _testStatistics[j] = Math.Abs(U - meanU) / (stdU + 1e-10);
         }

--- a/src/Preprocessing/FeatureSelection/TimeSeries/SeasonalityFS.cs
+++ b/src/Preprocessing/FeatureSelection/TimeSeries/SeasonalityFS.cs
@@ -100,7 +100,7 @@ public class SeasonalityFS<T> : TransformerBase<T, Matrix<T>, Matrix<T>>
                 }
 
                 // Spectral power at this frequency
-                double power = (cosSum * cosSum + sinSum * sinSum) / (n * n);
+                double power = (cosSum * cosSum + sinSum * sinSum) / ((double)n * n);
                 maxPower = Math.Max(maxPower, power);
             }
 

--- a/src/Preprocessing/TextVectorizers/FastTextVectorizer.cs
+++ b/src/Preprocessing/TextVectorizers/FastTextVectorizer.cs
@@ -46,7 +46,6 @@ public class FastTextVectorizer<T> : TextVectorizerBase<T>
 
     private Dictionary<string, double[]>? _wordVectors;
     private double[,]? _subwordVectors; // Hash bucket vectors
-    private HashSet<string>? _knownWords;
 
     /// <summary>
     /// Gets the learned word vectors for known words.
@@ -188,7 +187,6 @@ public class FastTextVectorizer<T> : TextVectorizerBase<T>
 
         _vocabulary = vocabArray.Select((k, i) => (k, i)).ToDictionary(x => x.k, x => x.i);
         _featureNames = Enumerable.Range(0, _vectorSize).Select(i => $"fasttext_dim_{i}").ToArray();
-        _knownWords = new HashSet<string>(vocabArray);
 
         if (vocabSize == 0)
         {

--- a/src/SurvivalAnalysis/RandomSurvivalForest.cs
+++ b/src/SurvivalAnalysis/RandomSurvivalForest.cs
@@ -299,8 +299,6 @@ public partial class RandomSurvivalForest<T> : SurvivalModelBase<T>
         double expected = 0;
         double variance = 0;
 
-        var leftSet = new HashSet<int>(leftIndices);
-
         foreach (double t in allEventTimes)
         {
             int leftAtRisk = leftIndices.Count(i => NumOps.ToDouble(times[i]) >= t);

--- a/src/SurvivalAnalysis/RandomSurvivalForest.cs
+++ b/src/SurvivalAnalysis/RandomSurvivalForest.cs
@@ -323,8 +323,8 @@ public partial class RandomSurvivalForest<T> : SurvivalModelBase<T>
             // Variance contribution
             if (totalAtRisk > 1)
             {
-                variance += (double)(leftAtRisk * rightAtRisk * totalEvents * (totalAtRisk - totalEvents))
-                           / (totalAtRisk * totalAtRisk * (totalAtRisk - 1));
+                variance += (double)leftAtRisk * rightAtRisk * totalEvents * (totalAtRisk - totalEvents)
+                           / ((double)totalAtRisk * totalAtRisk * (totalAtRisk - 1));
             }
         }
 

--- a/src/TimeSeries/DeepARModel.cs
+++ b/src/TimeSeries/DeepARModel.cs
@@ -576,7 +576,6 @@ public partial class DeepARModel<T> : TimeSeriesModelBase<T>
     /// </summary>
     public Dictionary<double, Vector<T>> ForecastWithQuantiles(Vector<T> history, double[] quantiles)
     {
-        var result = new Dictionary<double, Vector<T>>();
         var samples = new List<Vector<T>>();
 
         for (int s = 0; s < _options.NumSamples; s++)

--- a/src/TimeSeries/UnobservedComponentsModel.cs
+++ b/src/TimeSeries/UnobservedComponentsModel.cs
@@ -751,13 +751,11 @@ public partial class UnobservedComponentsModel<T, TInput, TOutput> : TimeSeriesM
     {
         int n = y.Length;
         var smoothedState = new List<Vector<T>>();
-        var smoothedCovariance = new List<Matrix<T>>();
 
         Vector<T> nextSmoothedState = _filteredState[n - 1];
         Matrix<T> nextSmoothedCovariance = _filteredCovariance[n - 1];
 
         smoothedState.Add(nextSmoothedState);
-        smoothedCovariance.Add(nextSmoothedCovariance);
 
         for (int t = n - 2; t >= 0; t--)
         {
@@ -772,7 +770,6 @@ public partial class UnobservedComponentsModel<T, TInput, TOutput> : TimeSeriesM
             Matrix<T> smoothedCovarianceT = filteredCovariance + smoother * (nextSmoothedCovariance - predictedCovariance) * smoother.Transpose();
 
             smoothedState.Insert(0, smoothedStateT);
-            smoothedCovariance.Insert(0, smoothedCovarianceT);
 
             nextSmoothedState = smoothedStateT;
             nextSmoothedCovariance = smoothedCovarianceT;

--- a/src/TransferLearning/DomainAdaptation/MMDDomainAdapter.cs
+++ b/src/TransferLearning/DomainAdaptation/MMDDomainAdapter.cs
@@ -112,10 +112,10 @@ public class MMDDomainAdapter<T> : IDomainAdapter<T>
         T sourceTargetSum = ComputeKernelSum(sourceData, targetData);
 
         // MMD^2 = E[k(x,x')] + E[k(y,y')] - 2*E[k(x,y)]
-        T mmd2 = _numOps.Divide(sourceSourceSum, _numOps.FromDouble(m * m));
-        mmd2 = _numOps.Add(mmd2, _numOps.Divide(targetTargetSum, _numOps.FromDouble(n * n)));
+        T mmd2 = _numOps.Divide(sourceSourceSum, _numOps.FromDouble((double)m * m));
+        mmd2 = _numOps.Add(mmd2, _numOps.Divide(targetTargetSum, _numOps.FromDouble((double)n * n)));
         mmd2 = _numOps.Subtract(mmd2, _numOps.Multiply(_numOps.FromDouble(2.0),
-            _numOps.Divide(sourceTargetSum, _numOps.FromDouble(m * n))));
+            _numOps.Divide(sourceTargetSum, _numOps.FromDouble((double)m * n))));
 
         // Return sqrt(MMD^2)
         T maxValue = MathHelper.Max(mmd2, _numOps.Zero);

--- a/src/Video/Generation/StableVideoDiffusion.cs
+++ b/src/Video/Generation/StableVideoDiffusion.cs
@@ -462,16 +462,6 @@ public partial class StableVideoDiffusion<T> : NeuralNetworkBase<T>
 
         var imageLatent = EncodeToLatent(lastFrame);
 
-        // Encode a few context frames for temporal consistency
-        int contextFrames = Math.Min(4, existingFrames.Count);
-        var contextLatents = new List<Tensor<T>>();
-        for (int i = existingFrames.Count - contextFrames; i < existingFrames.Count; i++)
-        {
-            var frame = existingFrames[i];
-            if (frame.Rank == 3) frame = AddBatchDimension(frame);
-            contextLatents.Add(EncodeToLatent(frame));
-        }
-
         // Generate new frames
         var newFrames = GenerateFromImage(lastFrame, 127, 7, seed);
 

--- a/src/Video/Inpainting/ProPainter.cs
+++ b/src/Video/Inpainting/ProPainter.cs
@@ -449,12 +449,10 @@ public partial class ProPainter<T> : VideoInpaintingBase<T>
         var encodedInput = ConcatenateChannelsDim1(maskedFrame, SingleChannelMask(mask));
 
         var imageFeatures = encodedInput;
-        var encoderOutputs = new List<Tensor<T>>();
         foreach (var encoder in _imageEncoder)
         {
             imageFeatures = encoder.Forward(imageFeatures);
             imageFeatures = ApplyReLU(imageFeatures);
-            encoderOutputs.Add(imageFeatures);
         }
 
         // Step 4: Apply transformer blocks for global context (Multi-Head Self-Attention)

--- a/src/WaveletFunctions/MeyerWavelet.cs
+++ b/src/WaveletFunctions/MeyerWavelet.cs
@@ -310,7 +310,7 @@ public class MeyerWavelet<T> : WaveletFunctionBase<T>
             }
             else if (freq <= 4.0 / 3)
             {
-                double v = Math.PI * (3 / 2 * freq - 1);
+                double v = Math.PI * (3.0 / 2 * freq - 1);
                 double psi = Math.Sin(Math.PI / 2 * Vf(v));
                 coefficients[i] = NumOps.FromDouble(psi);
             }

--- a/tests/AiDotNet.Tests/AiDotNetTests.csproj
+++ b/tests/AiDotNet.Tests/AiDotNetTests.csproj
@@ -86,6 +86,11 @@
          targets netstandard2.0 and cannot reference the analysed assembly; if the two ever disagree it
          emits the wrong axis name into generated contracts, which compiles and is silently wrong. -->
     <Compile Include="..\..\src\AiDotNet.Generators\ShapeContractGenerator.cs" Link="Generators\ShapeContractGenerator.cs" />
+    <!-- Linked so GeneratorContainmentWalkTests can drive these two generators through Roslyn and
+         pin their containing-type walks (which types the generated factory table / YAML registry
+         can name). -->
+    <Compile Include="..\..\src\AiDotNet.Generators\LayerStateGenerator.cs" Link="Generators\LayerStateGenerator.cs" />
+    <Compile Include="..\..\src\AiDotNet.Generators\YamlConfigSourceGenerator.cs" Link="Generators\YamlConfigSourceGenerator.cs" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net10.0'">

--- a/tests/AiDotNet.Tests/Audio/MusicAnalysis/BeatTrackerLagBoundsPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/Audio/MusicAnalysis/BeatTrackerLagBoundsPrecisionTests.cs
@@ -1,0 +1,48 @@
+using AiDotNet.Audio.MusicAnalysis;
+using AiDotNet.Tensors.LinearAlgebra;
+using Xunit;
+
+namespace AiDotNet.Tests.Audio.MusicAnalysis
+{
+    /// <summary>
+    /// Regression test for the autocorrelation lag bounds in <see cref="BeatTracker{T}"/>'s tempo
+    /// estimate. The bounds used to compute the frame rate as SampleRate / HopLength in integer
+    /// arithmetic, truncating it before converting BPM to a lag, so the lag window could be too short
+    /// to contain the true beat period.
+    /// </summary>
+    public class BeatTrackerLagBoundsPrecisionTests
+    {
+        [Fact]
+        public void Track_NonIntegerFrameRate_SearchesTheFullTempoLagRange()
+        {
+            // Frame rate = 2900 / 1000 = 2.9 frames/s. Clicks every 4 hops -> beat period of 4 frames,
+            // i.e. 60 * 2.9 / 4 = 43.5 BPM, which lies inside [MinTempo, MaxTempo] = [30, 60].
+            // Correct lag window: [(int)(2.9 * 60 / 60), (int)(2.9 * 60 / 30)) = [2, 5) -> finds lag 4.
+            // Truncated frame rate 2 gave [2, 4) -> lag 4 was never searched and the estimate was
+            // lag 3 = 58 BPM.
+            const int hop = 1000;
+            const int periods = 60;
+            var options = new BeatTrackerOptions
+            {
+                SampleRate = 2900,
+                HopLength = hop,
+                FftSize = 512,
+                MinTempo = 30.0,
+                MaxTempo = 60.0,
+                SmoothingWindow = 0
+            };
+            var tracker = new BeatTracker<double>(options);
+
+            // One unit click per beat, offset so it falls inside exactly one (centred) STFT frame.
+            var audio = new Tensor<double>([periods * 4 * hop]);
+            for (int beat = 0; beat < periods; beat++)
+            {
+                audio[beat * 4 * hop + 128] = 1.0;
+            }
+
+            var result = tracker.Track(audio);
+
+            Assert.Equal(43.5, result.Tempo, 6);
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/Generators/GeneratorContainmentWalkTests.cs
+++ b/tests/AiDotNet.Tests/Generators/GeneratorContainmentWalkTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Xunit;
+
+namespace AiDotNet.Tests.Generators;
+
+/// <summary>
+/// Pins the containing-type walks in <c>LayerStateGenerator.Analyze</c> (a layer the generated
+/// factory table cannot name is declined) and in <c>YamlConfigSourceGenerator</c>'s
+/// <c>IsEffectivelyPublicForGeneratedCode</c> / <c>HasOnlyResolvableTypeParametersForRegistry</c>
+/// (a [YamlConfigurable] type the registry cannot name is not registered).
+/// </summary>
+/// <remarks>
+/// Those walks were rewritten from <c>for (x = type; x is not null; x = x.ContainingType)</c> to a
+/// do/while so CodeQL's nullness analysis stops reporting the already-dereferenced start symbol as
+/// always null (cs/dereferenced-value-is-always-null). The rewrite must keep visiting the type itself
+/// AND every containing type; these tests fail if either end of the chain is dropped.
+/// </remarks>
+public class GeneratorContainmentWalkTests
+{
+    private const string LayerInfrastructure = @"
+namespace AiDotNet.Attributes
+{
+    [System.AttributeUsage(System.AttributeTargets.Parameter)]
+    public sealed class LayerStateAttribute : System.Attribute { public string? Key { get; set; } }
+}
+namespace AiDotNet.NeuralNetworks.Layers
+{
+    public abstract class LayerBase<T> { }
+}";
+
+    private const string YamlInfrastructure = @"
+namespace AiDotNet.Configuration
+{
+    [System.AttributeUsage(System.AttributeTargets.Class | System.AttributeTargets.Interface)]
+    public sealed class YamlConfigurableAttribute : System.Attribute
+    {
+        public YamlConfigurableAttribute(string sectionName) { }
+    }
+}
+namespace AiDotNet
+{
+    public class AiModelBuilder
+    {
+        public AiModelBuilder ConfigureSeed(int seed) => this;
+    }
+}";
+
+    private static ImmutableArray<MetadataReference> References()
+    {
+        var references = new List<MetadataReference>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (var assembly in AppDomain.CurrentDomain.GetAssemblies())
+        {
+            if (assembly.IsDynamic || string.IsNullOrEmpty(assembly.Location)
+                || !seen.Add(assembly.Location)) continue;
+            references.Add(MetadataReference.CreateFromFile(assembly.Location));
+        }
+        return references.ToImmutableArray();
+    }
+
+    private static (string Generated, ImmutableArray<Diagnostic> Diagnostics) Run(
+        IIncrementalGenerator generator, string infrastructure, string source)
+    {
+        var compilation = CSharpCompilation.Create(
+            "GeneratorContainmentWalk",
+            new[] { CSharpSyntaxTree.ParseText(infrastructure), CSharpSyntaxTree.ParseText(source) },
+            References(),
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary, nullableContextOptions: NullableContextOptions.Enable));
+        GeneratorDriver driver = CSharpGeneratorDriver.Create(generator);
+        driver = driver.RunGenerators(compilation);
+        var result = driver.GetRunResult();
+        return (string.Join("\n", result.GeneratedTrees.Select(t => t.GetText().ToString())), result.Diagnostics);
+    }
+
+    private const string LayerSource = @"
+using AiDotNet.Attributes;
+using AiDotNet.NeuralNetworks.Layers;
+
+namespace Walk
+{
+    public partial class TopLevelLayer<T> : LayerBase<T>
+    {
+        private readonly int _units;
+        public TopLevelLayer([LayerState] int units) { _units = units; }
+    }
+
+    public partial class PublicOuter
+    {
+        public partial class PublicNestedLayer<T> : LayerBase<T>
+        {
+            private readonly int _units;
+            public PublicNestedLayer([LayerState] int units) { _units = units; }
+        }
+
+        // The type ITSELF is unreachable: the first link of the walk.
+        private partial class PrivateNestedLayer<T> : LayerBase<T>
+        {
+            private readonly int _units;
+            public PrivateNestedLayer([LayerState] int units) { _units = units; }
+        }
+
+        private protected partial class PrivateProtectedNestedLayer<T> : LayerBase<T>
+        {
+            private readonly int _units;
+            public PrivateProtectedNestedLayer([LayerState] int units) { _units = units; }
+        }
+
+        // The type is public but a CONTAINING type is not: only a walk that continues past the
+        // first link declines it.
+        private partial class PrivateMiddle
+        {
+            public partial class PublicLayerInsidePrivateMiddle<T> : LayerBase<T>
+            {
+                private readonly int _units;
+                public PublicLayerInsidePrivateMiddle([LayerState] int units) { _units = units; }
+            }
+        }
+    }
+}";
+
+    [Fact]
+    public void LayerStateGenerator_EmitsFactoriesOnlyForLayersNameableFromTheFactoryTable()
+    {
+        var (generated, diagnostics) = Run(new AiDotNet.Generators.LayerStateGenerator(), LayerInfrastructure, LayerSource);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+
+        // Reachable layers, including one nested in a public type, get a factory entry.
+        Assert.Contains("TopLevelLayer<>", generated, StringComparison.Ordinal);
+        Assert.Contains("PublicOuter.PublicNestedLayer<>", generated, StringComparison.Ordinal);
+
+        // Unreachable ones are declined silently: the type itself private/private protected, or a
+        // public type inside a private containing type.
+        Assert.DoesNotContain("PrivateNestedLayer", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("PrivateProtectedNestedLayer", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("PublicLayerInsidePrivateMiddle", generated, StringComparison.Ordinal);
+    }
+
+    private const string YamlSource = @"
+using AiDotNet.Configuration;
+
+namespace Walk
+{
+    [YamlConfigurable(""TopLevelSection"")]
+    public class TopLevelConcrete { }
+
+    public class PublicOuter
+    {
+        [YamlConfigurable(""PublicNestedSection"")]
+        public class PublicNestedConcrete { }
+    }
+
+    internal class InternalOuter
+    {
+        // Public itself, unreachable through its containing type.
+        [YamlConfigurable(""HiddenByOuterSection"")]
+        public class HiddenByOuterConcrete { }
+    }
+
+    public class OuterWithForeignTypeParameter<TKey>
+    {
+        // The registry can only close T / TInput / TOutput; TKey lives on the CONTAINING type.
+        [YamlConfigurable(""ForeignTypeParameterSection"")]
+        public class ForeignTypeParameterConcrete { }
+    }
+
+    [YamlConfigurable(""OwnForeignTypeParameterSection"")]
+    public class OwnForeignTypeParameterConcrete<TKey> { }
+}";
+
+    [Fact]
+    public void YamlConfigSourceGenerator_RegistersOnlyTypesTheRegistryCanName()
+    {
+        var (generated, diagnostics) = Run(new AiDotNet.Generators.YamlConfigSourceGenerator(), YamlInfrastructure, YamlSource);
+
+        Assert.DoesNotContain(diagnostics, d => d.Severity == DiagnosticSeverity.Error);
+
+        Assert.Contains("Walk.TopLevelConcrete", generated, StringComparison.Ordinal);
+        Assert.Contains("Walk.PublicOuter.PublicNestedConcrete", generated, StringComparison.Ordinal);
+
+        // IsEffectivelyPublicForGeneratedCode must check the containing chain, not just the type.
+        Assert.DoesNotContain("HiddenByOuterConcrete", generated, StringComparison.Ordinal);
+
+        // HasOnlyResolvableTypeParametersForRegistry must collect the type's own type parameters
+        // AND those of every containing type.
+        Assert.DoesNotContain("ForeignTypeParameterConcrete", generated, StringComparison.Ordinal);
+        Assert.DoesNotContain("OwnForeignTypeParameterConcrete", generated, StringComparison.Ordinal);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Classification/MultiLabelGradientPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Classification/MultiLabelGradientPrecisionTests.cs
@@ -1,0 +1,74 @@
+using AiDotNet.Classification.MultiLabel;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Classification;
+
+/// <summary>
+/// Regression tests for the gradient average in <c>MultiLabelClassifierBase.ComputeGradients</c>.
+/// The divisor rows * labels * parameters used to be computed in 32-bit integer arithmetic, so once
+/// the product passed int.MaxValue it wrapped negative and flipped the sign of every gradient.
+/// </summary>
+public class MultiLabelGradientPrecisionTests
+{
+    [Fact]
+    public void ComputeGradients_WhenRowsLabelsParametersProductExceedsInt32_KeepsCorrectSignAndMagnitude()
+    {
+        const int rows = 1000;
+        const int labels = 100;
+        // 1000 * 100 * 21475 = 2,147,500,000 > int.MaxValue (2,147,483,647): the old int product
+        // wrapped to -2,147,467,296, turning the average gradient negative.
+        var model = new ConstantProbabilityMultiLabelStub { NumLabels = labels };
+        var input = new Matrix<double>(rows, 1);
+        var target = new Matrix<double>(rows, labels);
+        for (int i = 0; i < rows; i++)
+        {
+            for (int l = 0; l < labels; l++)
+            {
+                target[i, l] = 0.25;
+            }
+        }
+
+        var gradients = model.ComputeGradients(input, target);
+
+        double pred = ConstantProbabilityMultiLabelStub.Probability;
+        double deriv = (pred - 0.25) / (pred * (1 - pred) + 1e-15);
+        double expected = rows * labels * deriv
+            / ((double)rows * labels * ConstantProbabilityMultiLabelStub.StubParameterCount);
+
+        Assert.Equal(ConstantProbabilityMultiLabelStub.StubParameterCount, gradients.Length);
+        Assert.True(gradients[0] > 0, $"Average gradient must stay positive, got {gradients[0]}.");
+        Assert.Equal(expected, gradients[0], 12);
+        Assert.Equal(expected, gradients[gradients.Length - 1], 12);
+    }
+
+    /// <summary>
+    /// Minimal multi-label model: predicts a constant probability for every label and exposes a
+    /// fixed-size parameter vector, so the gradient divisor can be driven past int.MaxValue with
+    /// tiny inputs.
+    /// </summary>
+    private sealed class ConstantProbabilityMultiLabelStub : MultiLabelClassifierBase<double>
+    {
+        public const int StubParameterCount = 21475;
+        public const double Probability = 0.75;
+
+        protected override void TrainMultiLabelCore(Matrix<double> features, Matrix<double> labels)
+        {
+        }
+
+        public override Matrix<double> PredictMultiLabelProbabilities(Matrix<double> input)
+        {
+            var probabilities = new Matrix<double>(input.Rows, NumLabels);
+            for (int i = 0; i < input.Rows; i++)
+            {
+                for (int l = 0; l < NumLabels; l++)
+                {
+                    probabilities[i, l] = Probability;
+                }
+            }
+
+            return probabilities;
+        }
+
+        public override Vector<double> GetParameters() => new Vector<double>(StubParameterCount);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Clustering/AdjustedRandIndexPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Clustering/AdjustedRandIndexPrecisionTests.cs
@@ -1,0 +1,39 @@
+using AiDotNet.Clustering.Evaluation;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.Clustering;
+
+/// <summary>
+/// Regression tests for the expected-index term of <see cref="AdjustedRandIndex{T}"/>. The product
+/// sum(C(a_i,2)) * sum(C(b_j,2)) was formed in 64-bit integer arithmetic before being widened, which
+/// overflows once each sum passes ~3e9 (a few hundred thousand points in a handful of clusters).
+/// </summary>
+public class AdjustedRandIndexPrecisionTests
+{
+    [Fact]
+    public void Compute_IndependentLabelingsOnLargeDataset_ReturnsNearZero()
+    {
+        const int n = 200_000;
+        var trueLabels = new Vector<double>(n);
+        var predLabels = new Vector<double>(n);
+        for (int i = 0; i < n; i++)
+        {
+            trueLabels[i] = i < n / 2 ? 0 : 1;
+            predLabels[i] = i % 2;
+        }
+
+        double result = new AdjustedRandIndex<double>().Compute(trueLabels, predLabels);
+
+        // Every contingency cell holds 50,000 points; each row/column sum is 100,000.
+        double sumNij = 4.0 * (50_000.0 * 49_999.0 / 2.0);          // 4,999,900,000
+        double sumA = 2.0 * (100_000.0 * 99_999.0 / 2.0);           // 9,999,900,000
+        double sumB = sumA;
+        double totalPairs = (double)n * (n - 1) / 2.0;              // 19,999,900,000
+        double expectedIndex = sumA * sumB / totalPairs;
+        double expected = (sumNij - expectedIndex) / (0.5 * (sumA + sumB) - expectedIndex);
+
+        // sumA * sumB = 9.9998e19 exceeds long.MaxValue (9.22e18); the wrapped product gave ~0.48.
+        Assert.Equal(expected, result, 9);
+        Assert.True(System.Math.Abs(result) < 1e-3, $"Independent labelings must give ARI ~ 0, got {result}.");
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/DecompositionMethods/AdditiveDecompositionPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/DecompositionMethods/AdditiveDecompositionPrecisionTests.cs
@@ -1,0 +1,40 @@
+using AiDotNet.DecompositionMethods.TimeSeriesDecomposition;
+using AiDotNet.Enums;
+using AiDotNet.Enums.AlgorithmTypes;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Tests.IntegrationTests.DecompositionMethods;
+
+/// <summary>
+/// Regression tests for the LOESS bandwidth in <see cref="AdditiveDecomposition{T}"/>'s STL path.
+/// The cycle-subseries LOESS bandwidth was <c>windowSize / 2</c> in integer arithmetic, so a
+/// subseries of 2 points (windowSize = 1) got a bandwidth of 0 and every weight became 0/0 = NaN.
+/// </summary>
+public class AdditiveDecompositionPrecisionTests
+{
+    [Fact(Timeout = 120000)]
+    public async Task STL_TwoFullSeasons_ProducesFiniteComponents()
+    {
+        // STL uses a fixed seasonal period of 12, so 24 points give exactly 2 points per cycle-subseries.
+        int n = 24;
+        var data = new double[n];
+        for (int i = 0; i < n; i++)
+        {
+            data[i] = 10.0 + 0.5 * i + 5.0 * Math.Sin(2.0 * Math.PI * i / 12.0);
+        }
+
+        var decomposition = new AdditiveDecomposition<double>(new Vector<double>(data), AdditiveDecompositionAlgorithmType.STL);
+
+        foreach (var component in new[] { DecompositionComponentType.Trend, DecompositionComponentType.Seasonal, DecompositionComponentType.Residual })
+        {
+            var values = decomposition.GetComponentAsVector(component);
+            Assert.Equal(n, values.Length);
+            for (int i = 0; i < values.Length; i++)
+            {
+                Assert.False(double.IsNaN(values[i]) || double.IsInfinity(values[i]),
+                    $"{component}[{i}] = {values[i]} is not finite.");
+            }
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Kernels/StringKernelPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Kernels/StringKernelPrecisionTests.cs
@@ -1,0 +1,42 @@
+using System.Linq;
+using AiDotNet.Kernels;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Tests.IntegrationTests.Kernels;
+
+/// <summary>
+/// Regression tests for integer-overflow in the <see cref="StringKernel{T}"/> count products.
+/// A single k-mer / word occurring more than 46,341 times made <c>count * count</c> overflow
+/// int32 before being accumulated into a double, turning the norms negative and the kernel NaN.
+/// </summary>
+public class StringKernelPrecisionTests
+{
+    private const int RepeatCount = 50_000; // 50,000^2 = 2.5e9 > int.MaxValue
+
+    [Fact(Timeout = 120000)]
+    public async Task Spectrum_HighlyRepeatedKmer_DoesNotOverflow()
+    {
+        var kernel = new StringKernel<double>(StringKernel<double>.KernelType.Spectrum, substringLength: 1);
+        string s1 = new string('A', RepeatCount);
+        string s2 = new string('A', RepeatCount + 10);
+
+        double similarity = kernel.Calculate(s1, s2);
+
+        Assert.False(double.IsNaN(similarity), "Spectrum kernel returned NaN (int32 overflow in count products).");
+        Assert.Equal(1.0, similarity, 12);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task BagOfWords_HighlyRepeatedWord_DoesNotOverflow()
+    {
+        var kernel = new StringKernel<double>(StringKernel<double>.KernelType.BagOfWords);
+        string s1 = string.Join(" ", Enumerable.Repeat("the", RepeatCount));
+        string s2 = string.Join(" ", Enumerable.Repeat("the", RepeatCount + 10));
+
+        double similarity = kernel.Calculate(s1, s2);
+
+        Assert.False(double.IsNaN(similarity), "Bag-of-words kernel returned NaN (int32 overflow in count products).");
+        Assert.Equal(1.0, similarity, 12);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Preprocessing/BinarizationOtsuPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Preprocessing/BinarizationOtsuPrecisionTests.cs
@@ -1,0 +1,42 @@
+using AiDotNet.Preprocessing.Document;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Tests.IntegrationTests.Preprocessing;
+
+/// <summary>
+/// Regression tests for integer overflow in Otsu's between-class variance
+/// (<c>wB * wF</c> was evaluated in int32 before being widened to double).
+/// </summary>
+public class BinarizationOtsuPrecisionTests
+{
+    [Fact(Timeout = 120000)]
+    public async Task Otsu_OnHundredThousandPixelBimodalImage_SeparatesTheTwoLevels()
+    {
+        // 250 x 400 = 100,000 pixels: top half 0.2 (histogram bin 51), bottom half 1.0 (bin 255).
+        // For every candidate threshold 51..254, wB = wF = 50,000 and wB * wF = 2.5e9, which
+        // overflowed int32 to a negative value, so no variance ever beat 0 and the threshold
+        // stayed at bin 0 (everything became foreground).
+        const int height = 250;
+        const int width = 400;
+        var data = new Vector<double>(height * width);
+        for (int y = 0; y < height; y++)
+        {
+            for (int x = 0; x < width; x++)
+            {
+                data[y * width + x] = y < height / 2 ? 0.2 : 1.0;
+            }
+        }
+
+        var image = new Tensor<double>(new[] { 1, height, width }, data);
+        var binarizer = new Binarization<double>();
+
+        var result = binarizer.OtsuBinarization(image);
+
+        // Correct Otsu threshold is bin 51 (0.2): dark pixels map to 0, bright pixels to 1.
+        Assert.Equal(0.0, result[0, 0, 0]);
+        Assert.Equal(0.0, result[0, height / 2 - 1, width - 1]);
+        Assert.Equal(1.0, result[0, height / 2, 0]);
+        Assert.Equal(1.0, result[0, height - 1, width - 1]);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/Preprocessing/FeatureSelectionRankStatisticPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Preprocessing/FeatureSelectionRankStatisticPrecisionTests.cs
@@ -1,0 +1,108 @@
+using AiDotNet.Preprocessing.FeatureSelection.Filter.Correlation;
+using AiDotNet.Preprocessing.FeatureSelection.Filter.Univariate;
+using Xunit;
+using System.Threading.Tasks;
+using StatisticalWilcoxonSignedRank = AiDotNet.Preprocessing.FeatureSelection.Filter.Statistical.WilcoxonSignedRank<double>;
+using UnivariateWilcoxonSignedRank = AiDotNet.Preprocessing.FeatureSelection.Filter.Univariate.WilcoxonSignedRank<double>;
+
+namespace AiDotNet.Tests.IntegrationTests.Preprocessing;
+
+/// <summary>
+/// Regression tests for int32 overflow in sample-count products used by rank and
+/// correlation feature-selection statistics (the products were computed in int and
+/// only then widened to double).
+/// </summary>
+public class FeatureSelectionRankStatisticPrecisionTests
+{
+    [Fact(Timeout = 120000)]
+    public async Task KruskalWallisTest_LargeTieGroups_AppliesTieCorrection()
+    {
+        // n = 3000, two classes of 1500, feature equal to the class label: each class is one
+        // tie group of 1500. 1500^3 = 3.375e9 overflowed int32 to a negative tie sum, so the tie
+        // correction was skipped (H = 2249.25). With the correction, a perfectly separating
+        // two-group feature gives H = n - 1 = 2999.
+        const int n = 3000;
+        var data = new Matrix<double>(n, 1);
+        var target = new Vector<double>(n);
+        for (int i = 0; i < n; i++)
+        {
+            double label = i < n / 2 ? 0.0 : 1.0;
+            data[i, 0] = label;
+            target[i] = label;
+        }
+
+        var selector = new KruskalWallisTest<double>(nFeaturesToSelect: 1);
+        selector.Fit(data, target);
+
+        Assert.NotNull(selector.HStatistics);
+        Assert.Equal(n - 1.0, selector.HStatistics[0], 1e-6);
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task StatisticalWilcoxonSignedRank_TwoThousandPairs_ComputesFiniteStdDev()
+    {
+        // 2000 strictly positive, distinct differences: W = 0, mean = 1,000,500,
+        // stdDev = sqrt(2000*2001*4001/24) ~ 25,830, z ~ -38.7, p ~ 0.
+        // 2000*2001*4001 = 1.6e10 overflowed int32 to a negative value, stdDev was NaN and the
+        // p-value fell back to 1.0.
+        const int n = 2000;
+        var (data, target) = BuildStrictlyPositiveDifferences(n);
+
+        var selector = new StatisticalWilcoxonSignedRank(nFeaturesToSelect: 1);
+        selector.Fit(data, target);
+
+        Assert.NotNull(selector.PValues);
+        Assert.True(selector.PValues[0] < 1e-6, $"Expected p-value near 0, got {selector.PValues[0]}");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task UnivariateWilcoxonSignedRank_TwoThousandPairs_ComputesFiniteSigma()
+    {
+        // Same construction as above for the Univariate variant: old sigma was NaN so the
+        // p-value fell back to 1.0 instead of ~0.
+        const int n = 2000;
+        var (data, target) = BuildStrictlyPositiveDifferences(n);
+
+        var selector = new UnivariateWilcoxonSignedRank(nFeaturesToSelect: 1);
+        selector.Fit(data, target);
+
+        Assert.NotNull(selector.PValues);
+        Assert.True(selector.PValues[0] < 1e-6, $"Expected p-value near 0, got {selector.PValues[0]}");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task PointBiserial_HundredThousandSamples_PerfectSeparationGivesCorrelationOne()
+    {
+        // n = 100,000 balanced classes, feature equal to the class label: r_pb = 1.
+        // n0 * n1 = 2.5e9 and n * n = 1e10 both overflowed int32 (pq = -1.27), so the
+        // correlation was NaN.
+        const int n = 100000;
+        var data = new Matrix<double>(n, 1);
+        var target = new Vector<double>(n);
+        for (int i = 0; i < n; i++)
+        {
+            double label = i < n / 2 ? 0.0 : 1.0;
+            data[i, 0] = label;
+            target[i] = label;
+        }
+
+        var selector = new PointBiserial<double>(nFeaturesToSelect: 1);
+        selector.Fit(data, target);
+
+        Assert.NotNull(selector.Correlations);
+        Assert.Equal(1.0, selector.Correlations[0], 1e-9);
+    }
+
+    private static (Matrix<double> Data, Vector<double> Target) BuildStrictlyPositiveDifferences(int n)
+    {
+        var data = new Matrix<double>(n, 1);
+        var target = new Vector<double>(n);
+        for (int i = 0; i < n; i++)
+        {
+            data[i, 0] = i + 1.0;
+            target[i] = 0.0;
+        }
+
+        return (data, target);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/SurvivalAnalysis/RandomSurvivalForestPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SurvivalAnalysis/RandomSurvivalForestPrecisionTests.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Reflection;
+using AiDotNet.SurvivalAnalysis;
+using Xunit;
+
+namespace AiDotNet.Tests.IntegrationTests.SurvivalAnalysis;
+
+/// <summary>
+/// Regression tests for the log-rank split statistic of <see cref="RandomSurvivalForest{T}"/>.
+/// The hypergeometric variance term N^2 (N - 1) was evaluated in 32-bit integers, which overflows
+/// as soon as a node has 1,291 or more subjects at risk, producing negative variance contributions
+/// and a wrong split score.
+/// </summary>
+public class RandomSurvivalForestPrecisionTests
+{
+    [Fact]
+    public void LogRankStatistic_WithMoreThan1290SubjectsAtRisk_MatchesDoublePrecisionReference()
+    {
+        const int n = 1400;
+        var times = new Vector<double>(n);
+        var events = new Vector<int>(n);
+        var left = new int[n / 2];
+        var right = new int[n / 2];
+        for (int i = 0; i < n; i++)
+        {
+            times[i] = i + 1;
+            events[i] = 1;
+            if (i % 2 == 0)
+            {
+                left[i / 2] = i;
+            }
+            else
+            {
+                right[i / 2] = i;
+            }
+        }
+
+        var method = typeof(RandomSurvivalForest<double>).GetMethod(
+            "ComputeLogRankStatistic", BindingFlags.NonPublic | BindingFlags.Instance);
+        Assert.NotNull(method);
+
+        var forest = new RandomSurvivalForest<double>(numTrees: 1, seed: 7);
+        object? raw = method?.Invoke(forest, new object[] { times, events, left, right });
+        double actual = Assert.IsType<double>(raw);
+
+        // Independent double-precision log-rank reference. With distinct times, one event occurs at
+        // each time t = 1..n; subject i (time i + 1) is at risk at t while i + 1 >= t.
+        double observed = 0, expected = 0, variance = 0;
+        for (int t = 1; t <= n; t++)
+        {
+            double leftAtRisk = 0, rightAtRisk = 0;
+            for (int i = 0; i < n; i++)
+            {
+                if (i + 1 < t) continue;
+                if (i % 2 == 0) leftAtRisk++; else rightAtRisk++;
+            }
+
+            double total = leftAtRisk + rightAtRisk;
+            if (total <= 1) continue;
+
+            double leftEvents = (t - 1) % 2 == 0 ? 1 : 0;
+            observed += leftEvents;
+            expected += leftAtRisk / total;
+            variance += leftAtRisk * rightAtRisk * (total - 1) / (total * total * (total - 1));
+        }
+
+        double reference = Math.Abs((observed - expected) / Math.Sqrt(variance));
+
+        // Old int arithmetic gave 0.12597...; the correct statistic is 0.11383...
+        Assert.Equal(reference, actual, 9);
+    }
+}

--- a/tests/AiDotNet.Tests/IntegrationTests/WaveletFunctions/MeyerWaveletPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/WaveletFunctions/MeyerWaveletPrecisionTests.cs
@@ -1,0 +1,53 @@
+using AiDotNet.WaveletFunctions;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Tests.IntegrationTests.WaveletFunctions;
+
+/// <summary>
+/// Regression tests for the Meyer wavelet's second transition band (2/3 &lt; f &lt;= 4/3).
+/// The band argument was written <c>3 / 2 * freq</c>, which integer-divides to <c>1 * freq</c>.
+/// </summary>
+public class MeyerWaveletPrecisionTests
+{
+    private static double Vf(double x) => x * x * (3 - 2 * x);
+
+    [Fact(Timeout = 120000)]
+    public async Task GetWaveletCoefficients_SecondBand_UsesThreeHalvesFrequencyScale()
+    {
+        var wavelet = new MeyerWavelet<double>();
+        var coefficients = wavelet.GetWaveletCoefficients();
+        int size = coefficients.Length;
+
+        int checkedCount = 0;
+        for (int i = 0; i < size; i++)
+        {
+            double freq = (double)i / size;
+            if (freq <= 2.0 / 3 || freq > 4.0 / 3)
+            {
+                continue;
+            }
+
+            double expected = Math.Sin(Math.PI / 2 * Vf(Math.PI * (1.5 * freq - 1)));
+            Assert.Equal(expected, coefficients[i], 10);
+            checkedCount++;
+        }
+
+        Assert.True(checkedCount > 0, "No coefficients fell in the second Meyer band.");
+    }
+
+    [Fact(Timeout = 120000)]
+    public async Task GetWaveletCoefficients_AtThreeQuarters_MatchesHandComputedValue()
+    {
+        var wavelet = new MeyerWavelet<double>();
+        var coefficients = wavelet.GetWaveletCoefficients();
+        int index = coefficients.Length * 3 / 4; // freq = 0.75
+
+        // v = pi * (1.5 * 0.75 - 1) = pi / 8; psi = sin(pi/2 * Vf(pi/8)) ~= 0.5112.
+        // The truncated 3 / 2 == 1 version gave v = -pi/4 and psi ~= -0.9612.
+        double v = Math.PI / 8;
+        double expected = Math.Sin(Math.PI / 2 * Vf(v));
+        Assert.Equal(expected, coefficients[index], 10);
+        Assert.True(coefficients[index] > 0.0);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Diffusion/Schedulers/FlowMatchingScheduleCollectionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Diffusion/Schedulers/FlowMatchingScheduleCollectionTests.cs
@@ -1,0 +1,66 @@
+using System.Threading.Tasks;
+using AiDotNet.Diffusion.Schedulers;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Diffusion.Schedulers;
+
+/// <summary>
+/// Regression tests for <see cref="FlowMatchingScheduler{T}.SetTimesteps"/>: the linearly spaced
+/// flow-matching schedule it builds must actually be installed. It used to be computed and then
+/// discarded in favour of the base integer-stride schedule, which stops far short of t = 0 whenever
+/// the step count does not divide the training timesteps.
+/// </summary>
+public class FlowMatchingScheduleCollectionTests
+{
+    [Fact(Timeout = 60000)]
+    public async Task SetTimesteps_NonDivisorStepCount_SpansTheWholeRangeDownToNearZero()
+    {
+        var scheduler = new FlowMatchingScheduler<double>(SchedulerConfig<double>.CreateRectifiedFlow());
+
+        scheduler.SetTimesteps(600);
+        var timesteps = scheduler.Timesteps;
+
+        Assert.Equal(600, timesteps.Length);
+        Assert.Equal(999, timesteps[0]);
+        // Linear spacing of 999/600 ~= 1.665 ends at round(1.665) = 2. The base stride
+        // (1000 / 600 = 1) stopped at 400, leaving a single 0.4-wide final Euler jump to t = 0.
+        Assert.Equal(2, timesteps[timesteps.Length - 1]);
+        for (int i = 1; i < timesteps.Length; i++)
+            Assert.True(timesteps[i] < timesteps[i - 1], $"Schedule not strictly decreasing at index {i}.");
+
+        await Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task SetTimesteps_28Steps_UsesLinearSpacingNotIntegerStride()
+    {
+        var scheduler = new FlowMatchingScheduler<double>(SchedulerConfig<double>.CreateRectifiedFlow());
+
+        scheduler.SetTimesteps(28);
+        var timesteps = scheduler.Timesteps;
+
+        Assert.Equal(28, timesteps.Length);
+        Assert.Equal(999, timesteps[0]);
+        // 999 - 27 * (999 / 28) = 35.68 -> 36. The base stride of 35 ended at 999 - 27 * 35 = 54.
+        Assert.Equal(36, timesteps[timesteps.Length - 1]);
+
+        await Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task SetTimesteps_AllTrainingSteps_HasNoRepeatedTimestep()
+    {
+        var scheduler = new FlowMatchingScheduler<double>(SchedulerConfig<double>.CreateRectifiedFlow());
+
+        scheduler.SetTimesteps(1000);
+        var timesteps = scheduler.Timesteps;
+
+        Assert.Equal(1000, timesteps.Length);
+        Assert.Equal(999, timesteps[0]);
+        Assert.Equal(0, timesteps[timesteps.Length - 1]);
+        for (int i = 1; i < timesteps.Length; i++)
+            Assert.True(timesteps[i] < timesteps[i - 1], $"Repeated or rising timestep at index {i}.");
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Evaluation/RankTestSampleCountPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Evaluation/RankTestSampleCountPrecisionTests.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Evaluation.Statistics;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Evaluation;
+
+/// <summary>
+/// Regression tests for integer overflow in the sample-count products of the non-parametric
+/// statistical tests (N*(N+1), N^3 - N, nr*(nr+1)*(2nr+1), grandTotal^2). Each product used to be
+/// evaluated in 32-bit int arithmetic and only then widened to double, so it wrapped (often to a
+/// negative value) at sample sizes that are ordinary for ML evaluation.
+/// </summary>
+public class RankTestSampleCountPrecisionTests
+{
+    [Fact]
+    public void CochranQ_LargeSampleCount_MatchesClosedForm()
+    {
+        // Two classifiers, all labels positive. Classifier A is correct on all n samples; B on the
+        // first m. Then Q reduces to (n - m)^2 / (n - m) = n - m. grandTotal = n + m = 59,990, whose
+        // square (3.6e9) overflowed int32 and made Q ~ 4.3e8 instead of 10.
+        const int n = 30000;
+        const int m = 29990;
+        var actuals = Enumerable.Repeat(1.0, n).ToArray();
+        var classifierA = Enumerable.Repeat(1.0, n).ToArray();
+        var classifierB = Enumerable.Range(0, n).Select(i => i < m ? 1.0 : 0.0).ToArray();
+
+        var result = new CochranQTest<double>().Test(new[] { classifierA, classifierB }, actuals);
+
+        Assert.Equal((double)(n - m), result.Statistic, 6);
+    }
+
+    [Fact]
+    public void KruskalWallis_TieCorrection_LargeN_MatchesDoublePrecisionReference()
+    {
+        // N = 1500 pooled observations with heavy ties. The tie-correction denominator N^3 - N
+        // (3.4e9) overflowed int32 to a negative number, turning the correction factor from ~0.994
+        // into ~1.023 and shrinking H by ~3%.
+        const int perGroup = 750;
+        var groupA = Enumerable.Range(0, perGroup).Select(i => (double)(i % 10)).ToArray();
+        var groupB = Enumerable.Range(0, perGroup).Select(i => (double)(i % 10) + 5.0).ToArray();
+
+        var result = new KruskalWallisTest<double>().Test(new[] { groupA, groupB });
+
+        double expected = ReferenceKruskalWallisH(groupA, groupB);
+        Assert.Equal(expected, result.Statistic, 1e-9 * Math.Abs(expected));
+    }
+
+    [Fact]
+    public void KruskalWallis_DunnPostHoc_LargeN_ReturnsFinitePValue()
+    {
+        // N = 50,000 identical observations: every mean rank is equal, so z = 0 and p = 1.
+        // N*(N+1) = 2.5e9 overflowed int32 to a negative number; its square root was NaN, so the
+        // p-value was NaN.
+        const int perGroup = 25000;
+        var groupA = Enumerable.Repeat(1.0, perGroup).ToArray();
+        var groupB = Enumerable.Repeat(1.0, perGroup).ToArray();
+
+        var results = new KruskalWallisTest<double>().DunnPostHoc(new[] { groupA, groupB });
+
+        double pValue = results[(0, 1)];
+        Assert.InRange(pValue, 0.999, 1.001);
+    }
+
+    [Fact]
+    public void WilcoxonSignedRank_LargeNonZeroPairCount_ReturnsFinitePValue()
+    {
+        // 2000 non-zero differences with magnitudes 1..2000 and alternating signs:
+        // W+ = 1,000,000, W- = 1,001,000, mean = 1,000,500, std = sqrt(2000*2001*4001/24) = 25,829.57,
+        // z = -0.01934, two-sided p = 0.9846. nr*(nr+1)*(2nr+1) = 1.6e10 overflowed int32 to a
+        // negative number, so std (and the p-value) was NaN.
+        const int n = 2000;
+        var sample1 = Enumerable.Range(0, n).Select(i => (i % 2 == 0 ? 1.0 : -1.0) * (i + 1)).ToArray();
+        var sample2 = new double[n];
+
+        var result = new WilcoxonSignedRankTest<double>().Test(sample1, sample2);
+
+        Assert.Equal(1_000_000.0, result.Statistic, 6);
+        Assert.InRange(result.PValue, 0.983, 0.986);
+    }
+
+    private static double ReferenceKruskalWallisH(double[] groupA, double[] groupB)
+    {
+        var pooled = groupA.Select(v => (value: v, group: 0))
+            .Concat(groupB.Select(v => (value: v, group: 1)))
+            .OrderBy(x => x.value)
+            .ToList();
+        double n = pooled.Count;
+
+        var rankSums = new double[2];
+        var tieSizes = new List<double>();
+        int start = 0;
+        while (start < pooled.Count)
+        {
+            int end = start;
+            while (end < pooled.Count && pooled[end].value == pooled[start].value)
+                end++;
+
+            double midRank = (start + 1 + end) / 2.0;
+            for (int i = start; i < end; i++)
+                rankSums[pooled[i].group] += midRank;
+            if (end - start > 1)
+                tieSizes.Add(end - start);
+            start = end;
+        }
+
+        double h = 12.0 / (n * (n + 1))
+                   * (rankSums[0] * rankSums[0] / groupA.Length + rankSums[1] * rankSums[1] / groupB.Length)
+                   - 3.0 * (n + 1);
+        double tieCorrection = 1.0 - tieSizes.Sum(t => t * t * t - t) / (n * n * n - n);
+        return h / tieCorrection;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Finance/NHiTSFinancePoolingCollectionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Finance/NHiTSFinancePoolingCollectionTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.Enums;
+using AiDotNet.Finance.Forecasting.Neural;
+using AiDotNet.Models.Options;
+using AiDotNet.NeuralNetworks;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Finance;
+
+/// <summary>
+/// Regression tests for the N-HiTS training-path (tape) pooling. It documented trimming the
+/// incomplete trailing window like the inference pooling does, but instead collected the trimmed
+/// slices into a list that was never used and then threw, so any lookback window that is not a
+/// multiple of every stack's pooling kernel could be predicted with but never trained.
+/// </summary>
+public class NHiTSFinancePoolingCollectionTests
+{
+    private static NHiTSFinance<double> CreateModel(int lookback, int horizon)
+    {
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            complexity: NetworkComplexity.Simple,
+            inputSize: lookback,
+            outputSize: horizon);
+
+        var options = new NHiTSOptions<double>
+        {
+            LookbackWindow = lookback,
+            ForecastHorizon = horizon,
+            HiddenLayerSize = 8,
+            NumHiddenLayers = 2,
+            DropoutRate = 0.0,
+            // 12 is not a multiple of the first stack's kernel (8): the tape path must pool the
+            // first 8 steps and drop the trailing 4, exactly as the inference pooling does.
+            PoolingKernelSizes = new[] { 8, 4, 1 }
+        };
+
+        return new NHiTSFinance<double>(architecture, options);
+    }
+
+    private static Tensor<double> Ramp(int length)
+    {
+        var tensor = new Tensor<double>(new[] { 1, length });
+        for (int i = 0; i < length; i++)
+            tensor[0, i] = 0.1 * i;
+        return tensor;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Train_LookbackNotAMultipleOfPoolingKernel_DoesNotThrow()
+    {
+        var model = CreateModel(lookback: 12, horizon: 4);
+
+        // Previously threw NotSupportedException("N-HiTS tape pooling: seqLen (12) must be a
+        // multiple of kernelSize (8)...").
+        var exception = Record.Exception(() => model.Train(Ramp(12), Ramp(4)));
+
+        Assert.Null(exception);
+
+        await Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ForwardForTraining_LookbackNotAMultipleOfPoolingKernel_ProducesFiniteForecast()
+    {
+        var model = CreateModel(lookback: 12, horizon: 4);
+
+        var output = model.ForwardForTraining(Ramp(12));
+
+        Assert.Equal(4, output.Length);
+        for (int i = 0; i < output.Length; i++)
+        {
+            double value = output.GetFlat(i);
+            Assert.False(double.IsNaN(value) || double.IsInfinity(value), $"Non-finite forecast at {i}.");
+        }
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GenomeActivationCollectionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/GenomeActivationCollectionTests.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Threading.Tasks;
+using AiDotNet.NeuralNetworks;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks;
+
+/// <summary>
+/// Regression tests for <see cref="Genome{T}.Activate"/>. Its per-node activation map used to be
+/// declared but never filled, so the documented activation step was a no-op and the encoded network
+/// computed a purely linear weighted sum.
+/// </summary>
+public class GenomeActivationCollectionTests
+{
+    private static double Sigmoid(double x) => 1.0 / (1.0 + Math.Exp(-x));
+
+    [Fact(Timeout = 60000)]
+    public async Task Activate_DirectConnection_SquashesOutputWithSigmoid()
+    {
+        var genome = new Genome<double>(inputSize: 1, outputSize: 1);
+        genome.AddConnection(fromNode: 0, toNode: 1, weight: 2.0, isEnabled: true, innovation: 0);
+
+        var output = genome.Activate(new Vector<double>(new[] { 1.0 }));
+
+        // Previously the raw weighted sum 2.0 was returned.
+        Assert.Equal(Sigmoid(2.0), output[0], 12);
+
+        await Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Activate_HiddenNode_IsActivatedBeforeItFeedsTheOutput()
+    {
+        // input 0 -> hidden 3 -> output 1
+        var genome = new Genome<double>(inputSize: 1, outputSize: 1);
+        genome.AddConnection(fromNode: 0, toNode: 3, weight: 1.0, isEnabled: true, innovation: 0);
+        genome.AddConnection(fromNode: 3, toNode: 1, weight: 1.0, isEnabled: true, innovation: 1);
+
+        var output = genome.Activate(new Vector<double>(new[] { 0.0 }));
+
+        // hidden = sigmoid(0) = 0.5 feeds the output, which is then sigmoid(0.5).
+        // Previously the linear network returned 0 (0 * 1 * 1).
+        Assert.Equal(Sigmoid(Sigmoid(0.0)), output[0], 12);
+
+        await Task.CompletedTask;
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task Activate_InputPassesThroughUnchangedIntoTheWeightedSum()
+    {
+        var genome = new Genome<double>(inputSize: 2, outputSize: 1);
+        genome.AddConnection(fromNode: 0, toNode: 2, weight: 0.5, isEnabled: true, innovation: 0);
+        genome.AddConnection(fromNode: 1, toNode: 2, weight: -1.5, isEnabled: true, innovation: 1);
+
+        var output = genome.Activate(new Vector<double>(new[] { 2.0, 1.0 }));
+
+        // Inputs are not squashed: output = sigmoid(0.5 * 2 - 1.5 * 1) = sigmoid(-0.5).
+        Assert.Equal(Sigmoid(-0.5), output[0], 12);
+
+        await Task.CompletedTask;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/SSMHelperEstimatePrecisionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/NeuralNetworks/Layers/SSM/SSMHelperEstimatePrecisionTests.cs
@@ -1,0 +1,31 @@
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks.Layers.SSM;
+using Moq;
+using Xunit;
+using System.Threading.Tasks;
+
+namespace AiDotNet.Tests.UnitTests.NeuralNetworks.Layers.SSM;
+
+/// <summary>
+/// Regression test for the int32 overflow in <c>EstimateMemorySavings</c>: the reduced-precision
+/// byte estimate computed <c>paramCount * targetBitWidth</c> in int arithmetic, which overflows
+/// once paramCount * bits exceeds int.MaxValue (e.g. 300M parameters at 8 bits).
+/// </summary>
+public class SSMHelperEstimatePrecisionTests
+{
+    [Fact(Timeout = 120000)]
+    public async Task EstimateMemorySavings_LargeLayer_DoesNotOverflow()
+    {
+        const long paramCount = 300_000_000;
+        var layer = new Mock<ILayer<float>>();
+        layer.Setup(l => l.ParameterCount).Returns(paramCount);
+
+        var (originalBytes, reducedBytes, ratio) =
+            SSMQuantizationHelper<float>.EstimateMemorySavings(layer.Object, 8);
+
+        // 300M params * 8 bits / 8 = 300,000,000 bytes, plus (300M / 128) groups * 8 bytes = 18,750,000.
+        Assert.Equal(paramCount * 4, originalBytes);
+        Assert.Equal(318_750_000L, reducedBytes);
+        Assert.True(ratio > 3.0 && ratio < 4.0, $"Ratio {ratio} should be just under 4x for 8-bit.");
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/PhysicsInformed/PINNs/MultiScalePINNPrecisionTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/PhysicsInformed/PINNs/MultiScalePINNPrecisionTests.cs
@@ -1,0 +1,76 @@
+using System;
+using AiDotNet.Enums;
+using AiDotNet.Interfaces;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.PhysicsInformed.Interfaces;
+using AiDotNet.PhysicsInformed.PINNs;
+using Moq;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.PhysicsInformed.PINNs;
+
+/// <summary>
+/// Regression tests for the per-epoch loss reported by <see cref="MultiScalePINN{T}"/>. The epoch
+/// loss is the mean of the per-batch losses, but it was divided by the integer quotient
+/// numPoints / batchSize, which drops the trailing partial batch from the count.
+/// </summary>
+public class MultiScalePINNPrecisionTests
+{
+    [Fact]
+    public void Solve_WithTrailingPartialBatch_ReportsMeanBatchLoss()
+    {
+        var architecture = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.OneDimensional,
+            taskType: NeuralNetworkTaskType.Regression,
+            inputSize: 1,
+            outputSize: 1);
+
+        // No-op optimizer: this test is about loss bookkeeping, not parameter updates.
+        var optimizer = new Mock<IGradientBasedOptimizer<double, Tensor<double>, Tensor<double>>>();
+
+        // 300 collocation points with the fixed batch size of 256 -> two batches (256 + 44).
+        var pinn = new MultiScalePINN<double>(
+            architecture,
+            new ConstantResidualPDE(),
+            Array.Empty<IBoundaryCondition<double>>(),
+            numCollocationPointsPerScale: 300,
+            trainingOptions: new MultiScaleTrainingOptions<double> { UseAdaptiveScaleWeighting = false },
+            optimizer: optimizer.Object);
+
+        var history = pinn.Solve(epochs: 1, verbose: false);
+
+        // Every point has residual 1 and the scale weight is 1, so each batch loss is exactly 1.0 and
+        // their mean is 1.0. The old divisor 300 / 256 == 1 reported the sum of both batches, 2.0.
+        Assert.Single(history.Losses);
+        Assert.Equal(1.0, history.Losses[0], 12);
+    }
+
+    /// <summary>
+    /// Single-scale PDE whose residual is identically 1, making every batch loss exactly 1.
+    /// </summary>
+    private sealed class ConstantResidualPDE : IMultiScalePDE<double>
+    {
+        public int NumberOfScales => 1;
+        public double[] ScaleCharacteristicLengths => new[] { 1.0 };
+        public int InputDimension => 1;
+        public int OutputDimension => 1;
+        public string Name => "Constant residual";
+
+        public double ComputeResidual(Vector<double> inputs, Vector<double> outputs, PDEDerivatives<double> derivatives) => 1.0;
+
+        public double ComputeScaleResidual(int scaleIndex, double[] inputs, double[] outputs, PDEDerivatives<double> derivatives) => 1.0;
+
+        public double ComputeScaleCoupling(
+            int coarseIndex,
+            int fineIndex,
+            double[] inputs,
+            double[] coarseOutputs,
+            double[] fineOutputs,
+            PDEDerivatives<double> coarseDerivatives,
+            PDEDerivatives<double> fineDerivatives) => 0.0;
+
+        public double GetScaleLossWeight(int scaleIndex) => 1.0;
+
+        public int GetScaleOutputDimension(int scaleIndex) => 1;
+    }
+}


### PR DESCRIPTION
## Summary

CodeQL reports 477 open **error-severity** alerts on `master`. This PR triages every one of them and fixes the real ones, one commit per logical fix (22 commits).

The two alerts that started this — `cs/dereferenced-value-is-always-null` in the source generators — are **false positives**. They are not suppressed; the code is restructured so it is provably non-null, and the restructuring is verified with the CodeQL CLI and pinned by new generator tests.

Of the remaining 475 alerts, **139 are real and fixed** and **336 are false positives left untouched**. Several of the real ones break at input sizes users actually hit (Wilcoxon at ~1,024 pairs, Otsu on a 305×305 image, adjusted Rand index at ~200k points).

⚠️ **One behaviour change needs your attention before merge: `Genome.Activate` now applies sigmoid** (details below).

---

## Root causes

### The two null-dereference alerts (false positives)

| Alert | Location | Why CodeQL is wrong |
|---|---|---|
| 20600 | `src/AiDotNet.Generators/LayerStateGenerator.cs:303` (`type.TypeKind`) | `type` was already dereferenced 20 lines earlier at `LayerStateGenerator.cs:283` (`type.IsAbstract`), so it cannot be null here. |
| 16913 | `src/AiDotNet.Generators/YamlConfigSourceGenerator.cs:1450` (`symbol.Constructors`) | The only caller (`YamlConfigSourceGenerator.cs:346`) passes a type it has already dereferenced at lines 321–324. |

Both are triggered by the same code shape — a containing-type walk written as
`for (x = start; x is not null; x = x.ContainingType)`:

- **`LayerStateGenerator.cs:290`** — CodeQL's nullness analysis does not separate the first iteration (where the loop variable still aliases `type`) from later ones, so it carried the loop-exit fact "the loop variable is null" back onto `type` and flagged the next dereference.
- **`YamlConfigSourceGenerator.cs:1473` and `:1486`** — in both helpers the only `return true` is reached by leaving that loop with the walk variable null. CodeQL therefore inferred "returns true ⇒ the argument is null" and treated each helper as a null-check method, so the caller's `if (!A(symbol) || !B(symbol)) return …;` fall-through read as "symbol is null". I confirmed by experiment that **either helper alone reproduces the alert**, which is why both are rewritten.

**Fix:** all three walks become `do { … } while (x is not null)`, so only the `ContainingType` links are null-tested and the already-dereferenced start symbol never is. Behaviour is identical.

### The real bugs

Root causes are listed per fix in the table further below; each commit message carries the alert numbers and the `file:line`.

---

## Triage table — all 477 error-severity alerts

| Rule | Alerts | Real, fixed | False positive |
|---|---:|---:|---:|
| `cs/dereferenced-value-is-always-null` | 2 | 0 | 2 (restructured, see above) |
| `cs/loss-of-precision` | 441 | 109 | 332 |
| `cs/unused-collection` | 29 | 29 | 0 |
| `cs/empty-collection` | 5 | 1 | 4 |
| **Total** | **477** | **139** | **338** |

### False-positive categories

**`cs/loss-of-precision` (332 FPs)** — the rule fires on an integer division or multiplication whose result becomes floating point. The four reasons a site is *not* a bug:

| Category | Count (approx.) | Example |
|---|---:|---|
| Product is small by construction | ~180 | panoptic id `cls * 1000`, `heads * headDim`, pixel coordinates `col * cellSize`, `9 * degreesOfFreedom` |
| Integer floor is intended and correct | ~70 | sinusoidal position encoding `2.0 * (d / 2)`, symmetric wavelet centre offsets `size / 2` on odd sizes, `sampleSize / stride` whole-stride counts |
| Product is the element count of an array that already exists | ~50 | `n * m` where a `Matrix(n, m)` / `new double[n*n]` is already allocated, so the allocation fails first |
| Numerator is already `double`, so no truncation happens | ~30 | `sum / (height * width)` with `double sum` |

Whole directories came out clean: all 84 alerts in ComputerVision / VisionLanguage / Document / Video are false positives (panoptic ids, pixel coordinates and RoPE pair indices).

**`cs/empty-collection` (4 FPs)** — `src/RetrievalAugmentedGeneration/Graph/Embeddings/KGEmbeddingBase.cs:32-35`. The `[]` initialisers are non-null defaults; `Train` reassigns and fills them, and every read is gated on `IsTrained`.

---

## Per-fix list

Ordered as the commits are. "Breaks at" is the input size where the old code produces a wrong answer, not merely a theoretical overflow.

| # | Commit | Root cause (`file:line`) | Breaks at |
|---|---|---|---|
| 1 | `eebe87779` fix(generators) | `LayerStateGenerator.cs:303`, `YamlConfigSourceGenerator.cs:1450` — false positives, walks rewritten | n/a (no behaviour change) |
| 2 | `721c7a62e` fix(wavelets) | `MeyerWavelet.cs:313` — `3 / 2 * freq` is integer division, so the band scale was `1 * freq` | **always**: at freq 0.75 the coefficient was −0.9612 instead of 0.5112 |
| 3 | `d7fd6a1d2` fix(decomposition) | `AdditiveDecomposition.cs:317` — `windowSize / 2` truncates the LOESS bandwidth to 0 | **two full seasons** (n = 24): tricube divides 0/0, seasonal component is NaN |
| 4 | `fb9a75c9e` fix(kernels) | `StringKernel.cs:186,194,198,451,459,463` — k-mer/word counts multiplied as `int` | count > 46,340 (a repeated k-mer in long DNA, "the" in a book): norm = sqrt(negative) = NaN |
| 5 | `7094add36` fix(neural-networks) | `EmbeddingLayer.cs:856`, `AudioVisualEventLocalizationNetwork.cs:1322`, `SSMQuantizationHelper.cs:161` | LLM vocab 152064 × 8192 × 2 = 2.5e9 → negative regularisation loss; ~346 1080p frames; >268M params at 8 bits → negative bytes |
| 6 | `c2b4ce663` fix(preprocessing) | `Binarization.cs:105,120,125` — Otsu `wB * wF` and histogram sums as `int` | **~92.7k pixels, i.e. a 305×305 image**: threshold stays 0, every pixel becomes foreground |
| 7 | `e92c72f85` fix(feature-selection) | 14 selectors: Kruskal-Wallis, Wilcoxon, Fisher exact, AMI, point-biserial, bimodality | **Wilcoxon signed-rank at 1,024 pairs** (n(n+1)(2n+1) wraps → stdDev NaN → p = 1); tie correction `count³` at 1,291; `n(n+1)`, `n0*n1`, `a*d`, `ai*bj` at ~46k–93k. `FisherExactTest.cs:113` also tested `b * c > 0` in `int`, which can flip sign; now `b > 0 && c > 0` |
| 8 | `18a195894` fix(feature-selection) | 12 selectors: `n*n` / `n1*n2` / `n*|near hits|` normalisers | n ≥ 46,341 samples. MMD, SURF/MultiSURF and SeasonalityFS (series length — minute bars reach it) have no n×n allocation guarding them; the distance-correlation and kernel selectors also allocate an n×n `double[,]` (≥17 GB, still allocatable on 64-bit .NET), so for those it is a large-memory edge |
| 9 | `8b0975e39` fix(dimensionality-reduction) | `SparsePCA.cs:380` — rows × features | > 2.1e9 elements |
| 10 | `ea8f5d0bd` fix(evaluation) | `CochranQTest.cs:88`, `DeLongTest.cs:145`, `KruskalWallisTest.cs:103,109,186`, `WilcoxonSignedRankTest.cs:100,101,110` | Cochran Q wrong once total successes pass 46,340; Kruskal-Wallis tie correction wrong from N = 1,291 and Dunn post-hoc p = NaN from 46,341; Wilcoxon p = NaN from ~1,291 non-zero pairs |
| 11 | `502176b4c` fix(audio) | `BeatTracker.cs:173-174` — `SampleRate / HopLength` integer division truncates the frame rate | any non-integer frame rate: the tempo lag window is cut short (2900/1000 → 58 BPM instead of 43.5). Default 22050/512 is unaffected |
| 12 | `9b174dc19` fix(audio) | `AudioClassifierBase.cs:232,238` — `numClasses * count` | 1000 classes × 2.2M samples → negative class weight |
| 13 | `dd0a38f37` fix(statistics) | `StatisticsHelper.cs:5845-5846` (Kendall tau), `KernelInceptionDistance.cs:255,268,281`, `MMDDomainAdapter.cs:115-118` | ~46k samples; 50k-sample feature sets are the standard KID size |
| 14 | `c51e93fc3` fix(clustering) | `AdjustedRandIndex.cs:142`, `XMeans.cs:404`, `GMeans.cs:363` | **ARI at ~200k points**: `sumA * sumB` = 9.9998e19 overflows `long`, ARI of independent labelings returns 0.4798 instead of ~0 |
| 15 | `78f0feb55` fix(survival) | `RandomSurvivalForest.cs:326-327` — log-rank variance numerator and denominator as `int` | ~1,291 subjects at risk; corrupts split selection |
| 16 | `be0fe951a` fix(classification) | `MultiLabelClassifierBase.cs:622` — rows × labels × parameters | 1000 × 100 × 21475 wraps → **gradient sign flips** |
| 17 | `08b5e7d37` fix(meta-learning) | `BOILAlgorithm.cs:610`, `MatchingNetworksAlgorithm.cs:305` | models > ~21.7M parameters → negative index |
| 18 | `64a39c6a8` fix(pinn) | `MultiScalePINN.cs:444` — epoch loss divided by `numPoints / batchSize` in integer arithmetic | any trailing partial batch (300 points reported 2× the mean batch loss); also divided by zero when numPoints < batchSize |
| 19 | `da85d4a70` fix(diffusion) | `FlowMatchingScheduler.cs:125` — built a linear timestep schedule, then discarded it and called `base.SetTimesteps` | any non-divisor step count: 600 of 1000 steps covered only t = 999…400; 28 steps ended at t = 54 instead of 36 |
| 20 | `f94efeb41` fix(finance) | `NHiTSFinance.cs:573` — tape-pooling collected trim slices, dropped them and threw `NotSupportedException` | **training failed** whenever the lookback is not a multiple of every pooling kernel (lookback 12, kernels {8,4,1}) |
| 21 | `1f9ad8ebe` fix(neat) | `Genome.cs:311` — `nodeActivations` was read but never filled | **always** — see the callout below |
| 22 | `0951d2d93` refactor | 27 write-only collections across 27 files | dead code; `ByteTrack._removedTracks` also grew without bound until `Reset` |

---

## ⚠️ Behaviour change: `Genome.Activate` now applies sigmoid

`src/NeuralNetworks/Genome.cs:311` declared a `nodeActivations` dictionary, read it in the final loop, and **never put anything in it**. The activation step that `Genome.Activate`'s own doc comment promises ("It applies activation functions to introduce non-linearity") was therefore a no-op, and **every genome evaluated as a purely linear network** — no matter how many hidden nodes it had.

The fix applies the logistic sigmoid to each non-input node that receives weighted input, and activates hidden nodes *before* their value propagates downstream. That is the convention `NEAT.ActivateGenome` already documents and implements (`src/NeuralNetworks/NEAT.cs:67`, `:1078`), so this aligns `Genome` with the rest of NEAT rather than inventing a rule.

**Impact:** any direct caller of `Genome.Activate` will see different outputs — they are now squashed into (0, 1) instead of being raw weighted sums. Trained genomes evolved against the old linear behaviour will behave differently. Nothing inside the repo depends on the old values (the full affected-area test run below is green), but this is a public API behaviour change and is the one item in this PR worth an explicit decision.

---

## Evidence

### Tests

| Run | Result |
|---|---|
| 30 new tests, on this branch | **30 passed** |
| 30 new tests, with only the source fixes reverted to `master` | **27 failed, 3 passed** |
| Existing tests across every touched area (66 name filters) | **2,802 passed, 0 failed, 17 skipped** (62 min) |

The 3 that pass in the "before" run are deliberate guards, not misses: the 2 `GeneratorContainmentWalkTests` (the generator change is a false-positive restructuring, so it must not change behaviour) and `SetTimesteps_AllTrainingSteps_HasNoRepeatedTimestep` (a schedule invariant that already held).

The generator tests have teeth: three mutants that drop either end of a containment walk (skip the type itself, skip the containing chain, or collect only the type's own type parameters) each fail them.

### Builds

| Target | Result |
|---|---|
| net10.0 (test project + library) | 0 errors |
| net8.0 | 0 errors |
| net471 | 0 errors |

No new compiler warnings appear in any changed or added file.

### CodeQL before/after

Run locally with **CodeQL CLI 2.27.0** — the same version CI uses — over a traced build of the generator project, full `security-and-quality` suite:

| | Results |
|---|---|
| `master` | 204 |
| this branch | 202 |

The two that disappear are exactly alerts 20600 and 16913. No new result appears. The 139 library fixes are not re-measured end-to-end: a full-repo traced CodeQL run takes ~70 min in CI and will report them on this PR.

---

## Blast radius / file map

**99 files changed, +1,313 / −196.**

| Area | Files | What changes |
|---|---:|---|
| `src/AiDotNet.Generators/` | 2 | Loop shape only, no behaviour change |
| `src/Preprocessing/FeatureSelection/` | 26 | One-token widening casts in statistics |
| `src/Evaluation/Statistics/` | 4 | Same |
| `src/NeuralNetworks/` (incl. `Genome.cs`, `NEAT.cs`, layers) | 7 | Widening casts; **`Genome.cs` behaviour change** |
| `src/Audio/`, `src/Kernels/`, `src/Metrics/`, `src/Helpers/`, `src/Clustering/`, `src/SurvivalAnalysis/`, `src/Classification/`, `src/MetaLearning/`, `src/TransferLearning/`, `src/WaveletFunctions/`, `src/DecompositionMethods/`, `src/Preprocessing/` (other) | 20 | Widening casts and three truncating divisions |
| `src/Diffusion/`, `src/Finance/`, `src/PhysicsInformed/` | 3 | Real behaviour fixes (schedule, pooling, epoch loss) |
| 27 files in the dead-code commit | 27 | Removals only |
| `tests/AiDotNet.Tests/` | 16 new files + 1 csproj | 30 new tests; the csproj links the two generators so Roslyn can drive them |

Risk concentrates in three places: `Genome.cs` (public behaviour change), `FlowMatchingScheduler.cs` (diffusion sampling now visits different timesteps — this is the fix, but it changes generated output), and `NHiTSFinance.cs` (a path that previously threw now runs). Everything else is a widening cast or a deletion of unread state.

---

## What this does not do

- **Does not suppress or dismiss any alert.** The two false-positive dereference alerts are resolved by restructuring; the 336 other false positives are left exactly as they are and will keep appearing until someone dismisses them in the code-scanning UI. This PR deliberately makes no judgement call there.
- **Does not fix the 336 false positives**, including ~50 sites where the product is bounded only by an allocation that would fail first. If you want them silenced rather than dismissed, that is a separate, much larger diff.
- **Does not change any `n*n` site into a different algorithm.** The distance-correlation and kernel selectors still allocate an n×n matrix; the fix stops the normaliser from wrapping, it does not make those selectors usable at 46k+ samples.
- **Does not add tests for fixes that need infeasible inputs** — Kendall tau, KID, the MMD adapter, X-means, G-means, DeLong, EmbeddingLayer, AudioVisual and BOIL/Matching Networks would need 46k+ samples through O(n²) loops, ~2e9-element matrices, or >21M-parameter models. They are fixed and reviewed but not covered.
- **Does not address the related-but-separate defects found while reading this code.** Worth their own issues: `MultiScalePINN` never runs a backward pass before updating (so `Solve` may never have worked with the default optimizer); `KruskalWallisTest.DunnPostHoc` stores ranks in sorted order but reads them in group order; NEAT's topological sort marks a node done after its first incoming connection and drops bias connections; `StableVideoDiffusion.ExtendVideo` ignores `numNewFrames`; ProPainter computes flow-warped frames it never uses; N-HiTS ignores its configured `PoolingModes`; the Kendall tau concordant/discordant counters are themselves `int` and overflow above ~65k.
- **Does not touch AiDotNet.Serving or AiDotNet.Playground.Functions.** Those are covered by the two companion PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
