### PR TITLE
fix(serving): close SQLite sandbox escape and neutralize logged request data

### DIFF
--- a/src/AiDotNet.Playground.Functions/StripeWebhook.cs
+++ b/src/AiDotNet.Playground.Functions/StripeWebhook.cs
@@ -118,8 +118,8 @@ public class StripeWebhook
         }
 
         _logger.LogInformation(
-            "Checkout completed for customer {CustomerId}, email {EmailDomain}, subscription {SubscriptionId}",
-            customerId, MaskEmail(customerEmail), session.SubscriptionId);
+            "Checkout completed for customer {CustomerId}, session {SessionId}, subscription {SubscriptionId}",
+            customerId, session.Id, session.SubscriptionId);
 
         // Determine tier from the subscription
         var tier = "pro"; // Default to pro since that's our only paid tier currently
@@ -157,8 +157,8 @@ public class StripeWebhook
         var tier = status == "canceled" ? "free" : "pro";
 
         _logger.LogInformation(
-            "Subscription updated for {EmailDomain}: status={Status}, tier={Tier}",
-            MaskEmail(customerEmail), status, tier);
+            "Subscription updated for customer {CustomerId}: status={Status}, tier={Tier}",
+            subscription.CustomerId, status, tier);
 
         await UpdateSupabaseProfile(customerEmail, tier, status, subscription.CustomerId);
     }
@@ -179,7 +179,7 @@ public class StripeWebhook
             return;
         }
 
-        _logger.LogInformation("Subscription deleted for {EmailDomain}, reverting to free tier", MaskEmail(customerEmail));
+        _logger.LogInformation("Subscription deleted for customer {CustomerId}, reverting to free tier", subscription.CustomerId);
 
         await UpdateSupabaseProfile(customerEmail, "free", "canceled", subscription.CustomerId);
     }
@@ -214,29 +214,16 @@ public class StripeWebhook
     }
 
     /// <summary>
-    /// Masks an email address for safe logging (e.g., "j***@example.com").
-    /// </summary>
-    private static string MaskEmail(string? email)
-    {
-        if (string.IsNullOrEmpty(email))
-        {
-            return "[no-email]";
-        }
-
-        var atIndex = email.IndexOf('@');
-        if (atIndex <= 0)
-        {
-            return "***";
-        }
-
-        return $"{email[0]}***@{email[(atIndex + 1)..]}";
-    }
-
-    /// <summary>
     /// Updates the user's subscription profile in Supabase.
     /// Throws on configuration or HTTP failures so the webhook can return 500
     /// and Stripe will retry the event.
     /// </summary>
+    /// <remarks>
+    /// The customer's email is used only to find the Supabase user; it is never logged, not even
+    /// partially (a masked "j***@domain" still leaks the domain, which identifies people on
+    /// personal or small-company domains). Logs correlate through the Stripe customer ID and the
+    /// Supabase user ID instead.
+    /// </remarks>
     private async Task UpdateSupabaseProfile(string email, string tier, string status, string? stripeCustomerId)
     {
         var supabaseUrl = Environment.GetEnvironmentVariable("SUPABASE_URL");
@@ -299,7 +286,7 @@ public class StripeWebhook
 
         if (string.IsNullOrEmpty(userId))
         {
-            _logger.LogWarning("No Supabase user found with email {EmailDomain}", MaskEmail(email));
+            _logger.LogWarning("No Supabase user found for Stripe customer {CustomerId}", stripeCustomerId);
             return;
         }
 
@@ -337,8 +324,8 @@ public class StripeWebhook
         if (patchResponse.IsSuccessStatusCode)
         {
             _logger.LogInformation(
-                "Updated profile for user {UserId} ({EmailDomain}): tier={Tier}, status={Status}, stripe_customer={CustomerId}",
-                userId, MaskEmail(email), tier, status, stripeCustomerId);
+                "Updated profile for user {UserId}: tier={Tier}, status={Status}, stripe_customer={CustomerId}",
+                userId, tier, status, stripeCustomerId);
         }
         else
         {

--- a/src/AiDotNet.Serving/Configuration/ServingSqlSandboxOptions.cs
+++ b/src/AiDotNet.Serving/Configuration/ServingSqlSandboxOptions.cs
@@ -13,8 +13,27 @@ public sealed class ServingSqlSandboxOptions
 
     public int MaxResultRows { get; set; } = 1000;
 
+    /// <summary>
+    /// Connection string for a Postgres server that sandboxed requests run against. When unset and
+    /// <see cref="EnableDockerFallback"/> is true, every request gets its own throwaway container instead.
+    /// </summary>
+    /// <remarks>
+    /// Caller-authored SQL (query, schema and seed scripts) executes with this credential. The per-request
+    /// schema and <c>search_path</c> are namespacing, not a security boundary: SQL can still name other
+    /// schemas and, through the multi-statement schema/seed scripts, issue transaction control. Point this at
+    /// a dedicated, disposable database whose role owns nothing else and cannot reach other databases.
+    /// </remarks>
     public string? PostgresConnectionString { get; set; }
 
+    /// <summary>
+    /// Connection string for a MySQL server that sandboxed requests run against. When unset and
+    /// <see cref="EnableDockerFallback"/> is true, every request gets its own throwaway container instead.
+    /// </summary>
+    /// <remarks>
+    /// Caller-authored SQL executes with this credential, and the per-request database is namespacing, not a
+    /// security boundary (SQL can name other databases). Use a dedicated server or an account whose grants
+    /// are limited to creating and using its own scratch databases.
+    /// </remarks>
     public string? MySqlConnectionString { get; set; }
 
     public bool EnableDockerFallback { get; set; } = true;
@@ -22,6 +41,11 @@ public sealed class ServingSqlSandboxOptions
     /// <summary>
     /// Optional named database contexts that can be referenced via <c>DbId</c> in <see cref="AiDotNet.ProgramSynthesis.Execution.SqlExecuteRequest"/>.
     /// </summary>
+    /// <remarks>
+    /// The same trust rule as <see cref="PostgresConnectionString"/> applies: caller SQL runs with each
+    /// context's credential, so every registered connection string must be a dedicated, least-privilege
+    /// sandbox database.
+    /// </remarks>
     public List<ServingSqlDbContextRegistration> DbContexts { get; set; } = new();
 
     /// <summary>

--- a/src/AiDotNet.Serving/Controllers/EmbeddingsController.cs
+++ b/src/AiDotNet.Serving/Controllers/EmbeddingsController.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Serving.Security;
 using System.Diagnostics;
 using AiDotNet.Serving.Configuration;
 using AiDotNet.Serving.Models;
@@ -57,7 +58,7 @@ public class EmbeddingsController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received text embedding request for model '{ModelName}'", modelName);
+            _logger.LogDebug("Received text embedding request for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
             // Validate request
             if (request.Texts == null || request.Texts.Length == 0)
@@ -69,13 +70,13 @@ public class EmbeddingsController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(modelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", modelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(modelName));
                 return NotFound(new { error = $"Model '{modelName}' not found" });
             }
 
             if (!modelInfo.IsMultimodal)
             {
-                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", modelName);
+                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", LogSanitizer.Sanitize(modelName));
                 return BadRequest(new { error = $"Model '{modelName}' is not a multimodal model" });
             }
 
@@ -108,13 +109,13 @@ public class EmbeddingsController : ControllerBase
 
             _logger.LogInformation(
                 "Text embedding completed for model '{ModelName}' in {ElapsedMs}ms (batch size: {BatchSize})",
-                modelName, sw.ElapsedMilliseconds, request.Texts.Length);
+                LogSanitizer.Sanitize(modelName), sw.ElapsedMilliseconds, request.Texts.Length);
 
             return Ok(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during text embedding for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unexpected error during text embedding for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError,
                 new { error = "An unexpected error occurred during text embedding." });
         }
@@ -141,7 +142,7 @@ public class EmbeddingsController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received image embedding request for model '{ModelName}'", modelName);
+            _logger.LogDebug("Received image embedding request for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
             // Validate request
             if (request.Images == null || request.Images.Length == 0)
@@ -153,13 +154,13 @@ public class EmbeddingsController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(modelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", modelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(modelName));
                 return NotFound(new { error = $"Model '{modelName}' not found" });
             }
 
             if (!modelInfo.IsMultimodal)
             {
-                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", modelName);
+                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", LogSanitizer.Sanitize(modelName));
                 return BadRequest(new { error = $"Model '{modelName}' is not a multimodal model" });
             }
 
@@ -192,13 +193,13 @@ public class EmbeddingsController : ControllerBase
 
             _logger.LogInformation(
                 "Image embedding completed for model '{ModelName}' in {ElapsedMs}ms (batch size: {BatchSize})",
-                modelName, sw.ElapsedMilliseconds, request.Images.Length);
+                LogSanitizer.Sanitize(modelName), sw.ElapsedMilliseconds, request.Images.Length);
 
             return Ok(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during image embedding for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unexpected error during image embedding for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError,
                 new { error = "An unexpected error occurred during image embedding." });
         }
@@ -225,7 +226,7 @@ public class EmbeddingsController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received similarity request for model '{ModelName}'", modelName);
+            _logger.LogDebug("Received similarity request for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
             // Validate request
             if (request.TextEmbeddings == null || request.TextEmbeddings.Length == 0)
@@ -242,13 +243,13 @@ public class EmbeddingsController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(modelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", modelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(modelName));
                 return NotFound(new { error = $"Model '{modelName}' not found" });
             }
 
             if (!modelInfo.IsMultimodal)
             {
-                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", modelName);
+                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", LogSanitizer.Sanitize(modelName));
                 return BadRequest(new { error = $"Model '{modelName}' is not a multimodal model" });
             }
 
@@ -283,13 +284,13 @@ public class EmbeddingsController : ControllerBase
 
             _logger.LogInformation(
                 "Similarity computed for model '{ModelName}' in {ElapsedMs}ms",
-                modelName, sw.ElapsedMilliseconds);
+                LogSanitizer.Sanitize(modelName), sw.ElapsedMilliseconds);
 
             return Ok(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during similarity computation for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unexpected error during similarity computation for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError,
                 new { error = "An unexpected error occurred during similarity computation." });
         }
@@ -316,7 +317,7 @@ public class EmbeddingsController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received zero-shot classification request for model '{ModelName}'", modelName);
+            _logger.LogDebug("Received zero-shot classification request for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
             // Validate request
             if (request.ImageData == null || request.ImageData.Length == 0)
@@ -333,13 +334,13 @@ public class EmbeddingsController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(modelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", modelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(modelName));
                 return NotFound(new { error = $"Model '{modelName}' not found" });
             }
 
             if (!modelInfo.IsMultimodal)
             {
-                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", modelName);
+                _logger.LogWarning("Model '{ModelName}' does not support multimodal operations", LogSanitizer.Sanitize(modelName));
                 return BadRequest(new { error = $"Model '{modelName}' is not a multimodal model" });
             }
 
@@ -375,13 +376,13 @@ public class EmbeddingsController : ControllerBase
 
             _logger.LogInformation(
                 "Zero-shot classification completed for model '{ModelName}' in {ElapsedMs}ms (labels: {LabelCount})",
-                modelName, sw.ElapsedMilliseconds, request.ClassLabels.Length);
+                LogSanitizer.Sanitize(modelName), sw.ElapsedMilliseconds, request.ClassLabels.Length);
 
             return Ok(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during zero-shot classification for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unexpected error during zero-shot classification for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError,
                 new { error = "An unexpected error occurred during zero-shot classification." });
         }

--- a/src/AiDotNet.Serving/Controllers/FederatedController.cs
+++ b/src/AiDotNet.Serving/Controllers/FederatedController.cs
@@ -83,7 +83,7 @@ public class FederatedController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get status for federated run {RunId}", runId);
+            _logger.LogError(ex, "Failed to get status for federated run {RunId}", LogSanitizer.Sanitize(runId));
             return BadRequest(new { error = "An unexpected error occurred while retrieving the federated run status." });
         }
     }
@@ -108,7 +108,7 @@ public class FederatedController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to join federated run {RunId}", runId);
+            _logger.LogError(ex, "Failed to join federated run {RunId}", LogSanitizer.Sanitize(runId));
             return BadRequest(new { error = "An unexpected error occurred while joining the federated run." });
         }
     }
@@ -133,7 +133,7 @@ public class FederatedController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to get parameters for federated run {RunId}", runId);
+            _logger.LogError(ex, "Failed to get parameters for federated run {RunId}", LogSanitizer.Sanitize(runId));
             return BadRequest(new { error = "An unexpected error occurred while retrieving federated run parameters." });
         }
     }
@@ -176,12 +176,12 @@ public class FederatedController : ControllerBase
         }
         catch (FileNotFoundException ex)
         {
-            _logger.LogWarning(ex, "Federated run artifact for {RunId} not found", runId);
+            _logger.LogWarning(ex, "Federated run artifact for {RunId} not found", LogSanitizer.Sanitize(runId));
             return NotFound(new { error = "Federated run artifact not found." });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to download federated run artifact for {RunId}", runId);
+            _logger.LogError(ex, "Failed to download federated run artifact for {RunId}", LogSanitizer.Sanitize(runId));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "An unexpected error occurred while downloading the run artifact." });
         }
     }
@@ -231,12 +231,12 @@ public class FederatedController : ControllerBase
         }
         catch (FileNotFoundException ex)
         {
-            _logger.LogWarning(ex, "Federated run artifact for {RunId} not found", runId);
+            _logger.LogWarning(ex, "Federated run artifact for {RunId} not found", LogSanitizer.Sanitize(runId));
             return NotFound(new { error = "Federated run artifact not found." });
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to release federated run artifact key for {RunId}", runId);
+            _logger.LogError(ex, "Failed to release federated run artifact key for {RunId}", LogSanitizer.Sanitize(runId));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "An unexpected error occurred while releasing the run artifact key." });
         }
     }
@@ -261,7 +261,7 @@ public class FederatedController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to submit update for federated run {RunId}", runId);
+            _logger.LogError(ex, "Failed to submit update for federated run {RunId}", LogSanitizer.Sanitize(runId));
             return BadRequest(new { error = "An unexpected error occurred while submitting the update." });
         }
     }
@@ -281,7 +281,7 @@ public class FederatedController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to aggregate round for federated run {RunId}", runId);
+            _logger.LogError(ex, "Failed to aggregate round for federated run {RunId}", LogSanitizer.Sanitize(runId));
             return BadRequest(new { error = "An unexpected error occurred while aggregating the round." });
         }
     }

--- a/src/AiDotNet.Serving/Controllers/InferenceController.cs
+++ b/src/AiDotNet.Serving/Controllers/InferenceController.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Serving.Security;
 using System.Diagnostics;
 using AiDotNet.Serving.Configuration;
 using AiDotNet.Serving.Models;
@@ -72,7 +73,7 @@ public class InferenceController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received prediction request for model '{ModelName}'", modelName);
+            _logger.LogDebug("Received prediction request for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
             // Validate request
             if (request.Features == null || request.Features.Length == 0)
@@ -88,7 +89,7 @@ public class InferenceController : ControllerBase
                 if (!string.IsNullOrEmpty(adapterId))
                 {
                     effectiveModelName = $"{modelName}__{adapterId}";
-                    _logger.LogDebug("Routing to model variant '{VariantName}' via adapter header", effectiveModelName);
+                    _logger.LogDebug("Routing to model variant '{VariantName}' via adapter header", LogSanitizer.Sanitize(effectiveModelName));
                 }
             }
 
@@ -96,7 +97,7 @@ public class InferenceController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(effectiveModelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", effectiveModelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(effectiveModelName));
                 return NotFound(new { error = $"Model '{effectiveModelName}' not found" });
             }
 
@@ -105,7 +106,7 @@ public class InferenceController : ControllerBase
             {
                 _logger.LogWarning(
                     "Request batch size {BatchSize} exceeds maximum {MaxSize} for model '{ModelName}' with batching disabled",
-                    request.Features.Length, MaxBatchSizeWhenBatchingDisabled, effectiveModelName);
+                    request.Features.Length, MaxBatchSizeWhenBatchingDisabled, LogSanitizer.Sanitize(effectiveModelName));
                 return StatusCode(StatusCodes.Status413PayloadTooLarge, new
                 {
                     error = $"Request batch size {request.Features.Length} exceeds maximum allowed ({MaxBatchSizeWhenBatchingDisabled}) when batching is disabled. Reduce the batch size or enable batching."
@@ -189,23 +190,23 @@ public class InferenceController : ControllerBase
 
             _logger.LogInformation(
                 "Prediction completed for model '{ModelName}' in {ElapsedMs}ms (batch size: {BatchSize})",
-                effectiveModelName, sw.ElapsedMilliseconds, batchSize);
+                LogSanitizer.Sanitize(effectiveModelName), sw.ElapsedMilliseconds, batchSize);
 
             return Ok(response);
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogError(ex, "Invalid operation during prediction for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Invalid operation during prediction for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "Model operation error." });
         }
         catch (NotSupportedException ex)
         {
-            _logger.LogError(ex, "Unsupported operation for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unsupported operation for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "Unsupported operation." });
         }
         catch (ArgumentException ex)
         {
-            _logger.LogError(ex, "Invalid argument during prediction for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Invalid argument during prediction for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             if (ex.Message.Contains("maximum allowed when batching is disabled", StringComparison.OrdinalIgnoreCase))
             {
                 return StatusCode(StatusCodes.Status413PayloadTooLarge, new
@@ -218,7 +219,7 @@ public class InferenceController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during prediction for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unexpected error during prediction for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "An unexpected error occurred during prediction." });
         }
     }
@@ -340,7 +341,7 @@ public class InferenceController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received text generation request for model '{ModelName}'", modelName);
+            _logger.LogDebug("Received text generation request for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
             // Validate request
             var validationError = request.Validate();
@@ -357,7 +358,7 @@ public class InferenceController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(modelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", modelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(modelName));
                 return NotFound(new SpeculativeDecodingResponse
                 {
                     Error = $"Model '{modelName}' not found",
@@ -381,19 +382,19 @@ public class InferenceController : ControllerBase
                 // The model loaded successfully but cannot generate text (e.g. it is a
                 // regression/classification model, not a token-to-logits language model).
                 _logger.LogWarning(
-                    "Text generation unavailable for model '{ModelName}': {Error}", modelName, response.Error);
+                    "Text generation unavailable for model '{ModelName}': {Error}", LogSanitizer.Sanitize(modelName), LogSanitizer.Sanitize(response.Error));
                 return BadRequest(response);
             }
 
             _logger.LogInformation(
                 "Text generation completed for model '{ModelName}' in {ElapsedMs}ms ({NumGenerated} tokens generated)",
-                modelName, sw.ElapsedMilliseconds, response.NumGenerated);
+                LogSanitizer.Sanitize(modelName), sw.ElapsedMilliseconds, response.NumGenerated);
 
             return Ok(response);
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during text generation for model '{ModelName}'", modelName);
+            _logger.LogError(ex, "Unexpected error during text generation for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
             sw.Stop();
             return StatusCode(500, new SpeculativeDecodingResponse
             {
@@ -436,7 +437,7 @@ public class InferenceController : ControllerBase
 
         try
         {
-            _logger.LogDebug("Received LoRA fine-tuning request for model '{ModelName}'", request.ModelName);
+            _logger.LogDebug("Received LoRA fine-tuning request for model '{ModelName}'", LogSanitizer.Sanitize(request.ModelName));
 
             // Validate request
             var validationError = request.Validate();
@@ -455,7 +456,7 @@ public class InferenceController : ControllerBase
             var modelInfo = _modelRepository.GetModelInfo(request.ModelName);
             if (modelInfo == null)
             {
-                _logger.LogWarning("Model '{ModelName}' not found", request.ModelName);
+                _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(request.ModelName));
                 return NotFound(new LoRAFineTuneResponse
                 {
                     Success = false,
@@ -493,7 +494,7 @@ public class InferenceController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error during LoRA fine-tuning for model '{ModelName}'", request.ModelName);
+            _logger.LogError(ex, "Unexpected error during LoRA fine-tuning for model '{ModelName}'", LogSanitizer.Sanitize(request.ModelName));
             sw.Stop();
             return StatusCode(500, new LoRAFineTuneResponse
             {

--- a/src/AiDotNet.Serving/Controllers/ModelsController.cs
+++ b/src/AiDotNet.Serving/Controllers/ModelsController.cs
@@ -93,7 +93,7 @@ public class ModelsController : ControllerBase
             }
 
             _logger.LogInformation("Attempting to load model '{ModelName}' from path '{Path}'",
-                request.Name, request.Path);
+                LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(request.Path));
 
             // Validate request
             if (string.IsNullOrWhiteSpace(request.Name))
@@ -117,7 +117,7 @@ public class ModelsController : ControllerBase
             // Check if model already exists
             if (_modelRepository.ModelExists(request.Name))
             {
-                _logger.LogWarning("Model '{ModelName}' already exists", request.Name);
+                _logger.LogWarning("Model '{ModelName}' already exists", LogSanitizer.Sanitize(request.Name));
                 return Conflict(new LoadModelResponse
                 {
                     Success = false,
@@ -141,7 +141,7 @@ public class ModelsController : ControllerBase
             if (!IsWithinRoot(candidatePath, modelsRoot))
             {
                 _logger.LogWarning("Attempted path traversal: requested path '{Path}' resolves outside model directory",
-                    request.Path);
+                    LogSanitizer.Sanitize(request.Path));
                 return BadRequest(new LoadModelResponse
                 {
                     Success = false,
@@ -152,7 +152,7 @@ public class ModelsController : ControllerBase
             // Check if file exists
             if (!System.IO.File.Exists(candidatePath))
             {
-                _logger.LogWarning("Model file not found at canonical path: {Path}", candidatePath);
+                _logger.LogWarning("Model file not found at canonical path: {Path}", LogSanitizer.Sanitize(candidatePath));
                 return BadRequest(new LoadModelResponse
                 {
                     Success = false,
@@ -174,7 +174,7 @@ public class ModelsController : ControllerBase
             catch (Exception ex)
             {
                 _logger.LogError(ex, "Failed to load model '{ModelName}' from '{Path}'",
-                    request.Name, candidatePath);
+                    LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(candidatePath));
                 return BadRequest(new LoadModelResponse
                 {
                     Success = false,
@@ -183,7 +183,7 @@ public class ModelsController : ControllerBase
             }
 
             _logger.LogInformation("Successfully loaded model '{ModelName}' from '{Path}'",
-                request.Name, candidatePath);
+                LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(candidatePath));
 
             // Optionally associate a tokenizer so the model can be served via the OpenAI-compatible API.
             // A tokenizer failure does not fail the load — the model is still usable via the native
@@ -204,20 +204,20 @@ public class ModelsController : ControllerBase
                     {
                         _logger.LogWarning(
                             "Attempted path traversal: tokenizer path '{TokenizerPath}' resolves outside the model directory; skipping tokenizer registration.",
-                            request.TokenizerPath);
+                            LogSanitizer.Sanitize(request.TokenizerPath));
                     }
                     else
                     {
                         _tokenizers.LoadAndRegister(request.Name, tokenizerPath);
                         _logger.LogInformation("Registered tokenizer for model '{ModelName}' from '{TokenizerPath}'",
-                            request.Name, tokenizerPath);
+                            LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(tokenizerPath));
                     }
                 }
                 catch (Exception ex)
                 {
                     _logger.LogWarning(ex, "Failed to load tokenizer for model '{ModelName}' from '{TokenizerPath}'; " +
                         "the model is loaded but the OpenAI API will be unavailable for it.",
-                        request.Name, request.TokenizerPath);
+                        LogSanitizer.Sanitize(request.Name), LogSanitizer.Sanitize(request.TokenizerPath));
                 }
             }
 
@@ -229,7 +229,7 @@ public class ModelsController : ControllerBase
         }
         catch (UnauthorizedAccessException ex)
         {
-            _logger.LogError(ex, "Access denied when loading model '{ModelName}'", request.Name);
+            _logger.LogError(ex, "Access denied when loading model '{ModelName}'", LogSanitizer.Sanitize(request.Name));
             return StatusCode(403, new LoadModelResponse
             {
                 Success = false,
@@ -238,7 +238,7 @@ public class ModelsController : ControllerBase
         }
         catch (FileNotFoundException ex)
         {
-            _logger.LogError(ex, "Model file not found for '{ModelName}'", request.Name);
+            _logger.LogError(ex, "Model file not found for '{ModelName}'", LogSanitizer.Sanitize(request.Name));
             return BadRequest(new LoadModelResponse
             {
                 Success = false,
@@ -247,7 +247,7 @@ public class ModelsController : ControllerBase
         }
         catch (IOException ex)
         {
-            _logger.LogError(ex, "I/O error loading model '{ModelName}'", request.Name);
+            _logger.LogError(ex, "I/O error loading model '{ModelName}'", LogSanitizer.Sanitize(request.Name));
             return StatusCode(500, new LoadModelResponse
             {
                 Success = false,
@@ -256,7 +256,7 @@ public class ModelsController : ControllerBase
         }
         catch (InvalidOperationException ex)
         {
-            _logger.LogError(ex, "Invalid operation when loading model '{ModelName}'", request.Name);
+            _logger.LogError(ex, "Invalid operation when loading model '{ModelName}'", LogSanitizer.Sanitize(request.Name));
             return StatusCode(500, new LoadModelResponse
             {
                 Success = false,
@@ -265,7 +265,7 @@ public class ModelsController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Unexpected error loading model '{ModelName}'", request.Name);
+            _logger.LogError(ex, "Unexpected error loading model '{ModelName}'", LogSanitizer.Sanitize(request.Name));
             return StatusCode(500, new LoadModelResponse
             {
                 Success = false,
@@ -301,12 +301,12 @@ public class ModelsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public ActionResult<ModelInfo> GetModel(string modelName)
     {
-        _logger.LogDebug("Retrieving information for model '{ModelName}'", modelName);
+        _logger.LogDebug("Retrieving information for model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
         var modelInfo = _modelRepository.GetModelInfo(modelName);
         if (modelInfo == null)
         {
-            _logger.LogWarning("Model '{ModelName}' not found", modelName);
+            _logger.LogWarning("Model '{ModelName}' not found", LogSanitizer.Sanitize(modelName));
             return NotFound(new { error = $"Model '{modelName}' not found" });
         }
 
@@ -325,19 +325,19 @@ public class ModelsController : ControllerBase
     [ProducesResponseType(StatusCodes.Status404NotFound)]
     public IActionResult UnloadModel(string modelName)
     {
-        _logger.LogInformation("Attempting to unload model '{ModelName}'", modelName);
+        _logger.LogInformation("Attempting to unload model '{ModelName}'", LogSanitizer.Sanitize(modelName));
 
         var success = _modelRepository.UnloadModel(modelName);
         if (!success)
         {
-            _logger.LogWarning("Model '{ModelName}' not found for unloading", modelName);
+            _logger.LogWarning("Model '{ModelName}' not found for unloading", LogSanitizer.Sanitize(modelName));
             return NotFound(new { error = $"Model '{modelName}' not found" });
         }
 
         _artifactService.RemoveProtectedArtifact(modelName);
         _tokenizers.Remove(modelName);
 
-        _logger.LogInformation("Model '{ModelName}' unloaded successfully", modelName);
+        _logger.LogInformation("Model '{ModelName}' unloaded successfully", LogSanitizer.Sanitize(modelName));
         return Ok(new { message = $"Model '{modelName}' unloaded successfully" });
     }
 
@@ -383,7 +383,7 @@ public class ModelsController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to download model artifact for '{ModelName}'", modelName);
+            _logger.LogError(ex, "Failed to download model artifact for '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "Failed to download model artifact." });
         }
     }
@@ -431,7 +431,7 @@ public class ModelsController : ControllerBase
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Failed to release model artifact key for '{ModelName}'", modelName);
+            _logger.LogError(ex, "Failed to release model artifact key for '{ModelName}'", LogSanitizer.Sanitize(modelName));
             return StatusCode(StatusCodes.Status500InternalServerError, new { error = "Failed to release model artifact key." });
         }
     }
@@ -531,7 +531,7 @@ public class ModelsController : ControllerBase
         }
 
         _logger.LogDebug("Model '{Name}' registered with {InputDim} input dimensions and {OutputDim} output dimensions",
-            name, inputDim, outputDim);
+            LogSanitizer.Sanitize(name), inputDim, outputDim);
 
         return new ModelInfo
         {

--- a/src/AiDotNet.Serving/Controllers/StripeController.cs
+++ b/src/AiDotNet.Serving/Controllers/StripeController.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Serving.Security;
 using AiDotNet.Serving.Security.Licensing;
 using AiDotNet.Validation;
 using Microsoft.AspNetCore.Authorization;
@@ -84,7 +85,7 @@ public sealed class StripeController : ControllerBase
             if (!isOwner)
             {
                 _logger.LogWarning("User {UserId} attempted portal access for unowned customer {CustomerId}",
-                    userId, request.StripeCustomerId);
+                    LogSanitizer.Sanitize(userId), LogSanitizer.Sanitize(request.StripeCustomerId));
                 return StatusCode(StatusCodes.Status403Forbidden,
                     new { error = "You do not have access to this billing portal." });
             }

--- a/src/AiDotNet.Serving/Sandboxing/Sql/SqlSandboxExecutor.cs
+++ b/src/AiDotNet.Serving/Sandboxing/Sql/SqlSandboxExecutor.cs
@@ -207,6 +207,7 @@ public sealed class SqlSandboxExecutor : ISqlSandboxExecutor
 
         await using var connection = new SqliteConnection(connectionString);
         await connection.OpenAsync(cancellationToken).ConfigureAwait(false);
+        ConfineSqliteToPrivateDatabase(connection);
 
         await ExecuteOptionalScriptAsync(connection, schemaSql, cancellationToken).ConfigureAwait(false);
         await ExecuteOptionalScriptAsync(connection, seedSql, cancellationToken).ConfigureAwait(false);
@@ -216,6 +217,23 @@ public sealed class SqlSandboxExecutor : ISqlSandboxExecutor
             createCommand: sql => CreateSqliteCommand(connection, sql),
             query: query,
             cancellationToken: cancellationToken).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Keeps caller SQL inside the connection's private <c>:memory:</c> database.
+    /// </summary>
+    /// <remarks>
+    /// The sandbox deliberately executes caller-authored SQL, so the containment boundary is the
+    /// connection itself. SQLite lets any statement open other database files on the host:
+    /// <c>ATTACH DATABASE '/path/app.db' AS x</c> reads or creates arbitrary files with the server's
+    /// permissions (for example the Serving persistence database holding license and API keys), and
+    /// <c>VACUUM INTO '/path/file'</c> writes one. Both go through SQLite's attach machinery, so capping
+    /// the number of attachable databases at zero closes them without restricting anything a
+    /// single-database schema/seed/query needs.
+    /// </remarks>
+    private static void ConfineSqliteToPrivateDatabase(SqliteConnection connection)
+    {
+        SQLitePCL.raw.sqlite3_limit(connection.Handle, SQLitePCL.raw.SQLITE_LIMIT_ATTACHED, 0);
     }
 
     private async Task<SqlExecuteResponse> ExecutePostgresAsync(

--- a/src/AiDotNet.Serving/Security/Licensing/LicenseService.cs
+++ b/src/AiDotNet.Serving/Security/Licensing/LicenseService.cs
@@ -87,7 +87,7 @@ public sealed class LicenseService : ILicenseService
 
             _logger.LogInformation(
                 "Created license key {KeyId} for {CustomerName} (Tier={Tier}, MaxSeats={MaxSeats})",
-                entity.KeyId, entity.CustomerName, entity.Tier, entity.MaxSeats);
+                entity.KeyId, LogSanitizer.Sanitize(entity.CustomerName), entity.Tier, entity.MaxSeats);
 
             return new LicenseCreateResponse
             {

--- a/src/AiDotNet.Serving/Security/Licensing/StripeService.cs
+++ b/src/AiDotNet.Serving/Security/Licensing/StripeService.cs
@@ -114,7 +114,7 @@ internal sealed class StripeService : IStripeService
 
         _logger.LogInformation(
             "Created Stripe Customer Portal session for customer {CustomerId}",
-            stripeCustomerId);
+            LogSanitizer.Sanitize(stripeCustomerId));
 
         return session.Url;
     }
@@ -405,7 +405,7 @@ internal sealed class StripeService : IStripeService
         {
             _logger.LogWarning(
                 "ValidateCustomerOwnership: Stripe customer {CustomerId} not found in database",
-                stripeCustomerId);
+                LogSanitizer.Sanitize(stripeCustomerId));
             return false;
         }
 
@@ -414,7 +414,7 @@ internal sealed class StripeService : IStripeService
         {
             _logger.LogWarning(
                 "ValidateCustomerOwnership: UserId mismatch for customer {CustomerId}",
-                stripeCustomerId);
+                LogSanitizer.Sanitize(stripeCustomerId));
             return false;
         }
 
@@ -429,7 +429,7 @@ internal sealed class StripeService : IStripeService
         {
             _logger.LogWarning(
                 "ValidateCustomerOwnership: No active subscription found for customer {CustomerId}",
-                stripeCustomerId);
+                LogSanitizer.Sanitize(stripeCustomerId));
         }
 
         return hasSubscription;

--- a/src/AiDotNet.Serving/Security/LogSanitizer.cs
+++ b/src/AiDotNet.Serving/Security/LogSanitizer.cs
@@ -1,0 +1,52 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
+
+namespace AiDotNet.Serving.Security;
+
+/// <summary>
+/// Neutralizes caller-controlled strings before they are written to a log entry (CWE-117, log forging).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Microsoft.Extensions.Logging renders structured-logging arguments verbatim into the formatted
+/// message, and plain-text sinks (the simple console formatter, file sinks, syslog forwarders) do not
+/// escape them. A route value such as <c>"m\r\n[warn] admin login ok"</c> would therefore start a
+/// forged log line. Every caller-controlled string passed to a logger in AiDotNet.Serving goes through
+/// <see cref="Sanitize"/> so the value is still recorded, but can never break out of its own entry.
+/// </para>
+/// <para>
+/// Escaped characters: all C0/C1 control characters (which includes CR, LF, TAB, NUL, ESC and NEL),
+/// the Unicode line/paragraph separators U+2028/U+2029, and the bidirectional embedding/override/isolate
+/// controls U+202A-U+202E and U+2066-U+2069 (which can visually reorder a log line). CR, LF and TAB are
+/// rendered as <c>\r</c>, <c>\n</c> and <c>\t</c>; everything else as <c>\uXXXX</c>. Printable text,
+/// including non-ASCII letters, is left untouched, so ordinary model names and paths log unchanged.
+/// </para>
+/// <para>
+/// This is for log output only. Never feed the sanitized value back into lookups, file paths or
+/// responses: the raw value remains the source of truth for request handling.
+/// </para>
+/// </remarks>
+internal static class LogSanitizer
+{
+    private static readonly Regex UnsafeCharacters = new(
+        @"[\p{Cc}\u2028\u2029\u202A-\u202E\u2066-\u2069]",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant,
+        TimeSpan.FromSeconds(1));
+
+    /// <summary>
+    /// Returns <paramref name="value"/> with every line-breaking or otherwise unsafe character escaped,
+    /// or <see langword="null"/> when <paramref name="value"/> is <see langword="null"/>.
+    /// </summary>
+    /// <param name="value">A caller-controlled value that is about to be logged.</param>
+    /// <returns>The value, safe to embed in a single log entry.</returns>
+    public static string? Sanitize(string? value) =>
+        value is null ? null : UnsafeCharacters.Replace(value, static match => Escape(match.Value[0]));
+
+    private static string Escape(char c) => c switch
+    {
+        '\r' => "\\r",
+        '\n' => "\\n",
+        '\t' => "\\t",
+        _ => "\\u" + ((int)c).ToString("X4", CultureInfo.InvariantCulture)
+    };
+}

--- a/src/AiDotNet.Serving/Services/TextGenerationService.cs
+++ b/src/AiDotNet.Serving/Services/TextGenerationService.cs
@@ -1,3 +1,4 @@
+using AiDotNet.Serving.Security;
 using AiDotNet.Serving.Configuration;
 using AiDotNet.Serving.ContinuousBatching;
 using AiDotNet.Serving.Models;
@@ -283,7 +284,7 @@ public sealed class TextGenerationService : ITextGenerationService
                 {
                     _logger.LogWarning(ex,
                         "Batched incremental generation failed for model '{ModelName}' with an active structured-output constraint; failing rather than retrying with the advanced constraint.",
-                        modelName);
+                        LogSanitizer.Sanitize(modelName));
                     return new SpeculativeDecodingResponse
                     {
                         Error = "Structured-output generation failed and cannot be safely retried.",
@@ -292,7 +293,7 @@ public sealed class TextGenerationService : ITextGenerationService
                 }
                 _logger.LogWarning(ex,
                     "Batched incremental generation failed for model '{ModelName}'; falling back to full-context decode.",
-                    modelName);
+                    LogSanitizer.Sanitize(modelName));
             }
         }
 
@@ -344,7 +345,7 @@ public sealed class TextGenerationService : ITextGenerationService
         {
             _logger.LogWarning(
                 "Text generation for model '{ModelName}' did not complete within the iteration budget.",
-                modelName);
+                LogSanitizer.Sanitize(modelName));
             return new SpeculativeDecodingResponse
             {
                 Error = "Text generation did not complete within the allotted budget.",

--- a/tests/AiDotNet.Playground.Functions.Tests/AiDotNet.Playground.Functions.Tests.csproj
+++ b/tests/AiDotNet.Playground.Functions.Tests/AiDotNet.Playground.Functions.Tests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\AiDotNet.Playground.Functions\AiDotNet.Playground.Functions.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/AiDotNet.Playground.Functions.Tests/StripeWebhookLoggingTests.cs
+++ b/tests/AiDotNet.Playground.Functions.Tests/StripeWebhookLoggingTests.cs
@@ -1,0 +1,207 @@
+using System.Collections.Concurrent;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting.Server;
+using Microsoft.AspNetCore.Hosting.Server.Features;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Stripe;
+using Xunit;
+
+namespace AiDotNet.Playground.Functions.Tests;
+
+/// <summary>
+/// Drives the real <see cref="StripeWebhook"/> end to end with a correctly signed Stripe event and a
+/// loopback fake of the Supabase admin/REST API, then inspects everything the function logged.
+/// </summary>
+/// <remarks>
+/// The tests mutate process-wide environment variables the function reads, so they live in one class
+/// (xUnit runs a class's tests sequentially) and restore the previous values afterwards.
+/// </remarks>
+public sealed class StripeWebhookLoggingTests : IAsyncLifetime
+{
+    private const string WebhookSecret = "whsec_test_do_not_leak_0123456789";
+    private const string SupabaseKey = "sb_secret_test_do_not_leak_9876543210";
+    private const string CustomerEmail = "jane.private@janes-family-domain.example";
+    private const string CustomerId = "cus_TEST123";
+
+    private static readonly string[] EnvNames = ["STRIPE_WEBHOOK_SECRET", "SUPABASE_URL", "SUPABASE_SECRET_KEY"];
+
+    private readonly Dictionary<string, string?> _savedEnv = new();
+    private readonly ConcurrentQueue<string> _supabaseRequests = new();
+    private WebApplication? _fakeSupabase;
+    private string _supabaseUsersJson = "{\"users\":[]}";
+
+    public async Task InitializeAsync()
+    {
+        foreach (var name in EnvNames)
+        {
+            _savedEnv[name] = Environment.GetEnvironmentVariable(name);
+        }
+
+        var builder = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseSetting("urls", "http://127.0.0.1:0");
+        _fakeSupabase = builder.Build();
+        _fakeSupabase.MapGet("/auth/v1/admin/users", () =>
+        {
+            _supabaseRequests.Enqueue("GET users");
+            return Results.Content(_supabaseUsersJson, "application/json");
+        });
+        _fakeSupabase.MapMethods("/rest/v1/profiles", ["PATCH"], async (HttpRequest request) =>
+        {
+            using var reader = new StreamReader(request.Body);
+            _supabaseRequests.Enqueue("PATCH " + request.QueryString + " " + await reader.ReadToEndAsync());
+            return Results.NoContent();
+        });
+        await _fakeSupabase.StartAsync();
+
+        var address = _fakeSupabase.Services.GetRequiredService<IServer>()
+            .Features.Get<IServerAddressesFeature>()!.Addresses.First();
+
+        Environment.SetEnvironmentVariable("STRIPE_WEBHOOK_SECRET", WebhookSecret);
+        Environment.SetEnvironmentVariable("SUPABASE_URL", address.TrimEnd('/'));
+        Environment.SetEnvironmentVariable("SUPABASE_SECRET_KEY", SupabaseKey);
+    }
+
+    public async Task DisposeAsync()
+    {
+        foreach (var (name, value) in _savedEnv)
+        {
+            Environment.SetEnvironmentVariable(name, value);
+        }
+
+        if (_fakeSupabase is not null)
+        {
+            await _fakeSupabase.DisposeAsync();
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task CheckoutCompleted_UpdatesProfile_WithoutLoggingEmailDerivedData()
+    {
+        _supabaseUsersJson = JsonSerializer.Serialize(new
+        {
+            users = new[] { new { id = "00000000-0000-0000-0000-00000000abcd", email = CustomerEmail } }
+        });
+        var logger = new CapturingLogger<StripeWebhook>();
+
+        var result = await new StripeWebhook(logger).Run(SignedRequest(CheckoutCompletedEvent()));
+
+        Assert.IsType<OkResult>(result);
+        Assert.Contains(_supabaseRequests, r => r.StartsWith("PATCH ?id=eq.00000000-0000-0000-0000-00000000abcd", StringComparison.Ordinal)
+                                                 && r.Contains(CustomerId, StringComparison.Ordinal));
+        Assert.Contains(logger.Entries, e => e.Contains(CustomerId, StringComparison.Ordinal));
+        AssertNoSensitiveData(logger.Entries);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task CheckoutCompleted_WithNoMatchingSupabaseUser_DoesNotLogEmailDerivedData()
+    {
+        _supabaseUsersJson = "{\"users\":[]}";
+        var logger = new CapturingLogger<StripeWebhook>();
+
+        var result = await new StripeWebhook(logger).Run(SignedRequest(CheckoutCompletedEvent()));
+
+        Assert.IsType<OkResult>(result);
+        Assert.DoesNotContain(_supabaseRequests, r => r.StartsWith("PATCH", StringComparison.Ordinal));
+        Assert.Contains(logger.Entries, e => e.Contains("No Supabase user found", StringComparison.Ordinal)
+                                             && e.Contains(CustomerId, StringComparison.Ordinal));
+        AssertNoSensitiveData(logger.Entries);
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task InvalidSignature_Rejected_WithoutEchoingSecretsOrPayload()
+    {
+        var logger = new CapturingLogger<StripeWebhook>();
+        var request = SignedRequest(CheckoutCompletedEvent(), signingSecret: "whsec_attacker_guess");
+
+        var result = await new StripeWebhook(logger).Run(request);
+
+        var badRequest = Assert.IsType<BadRequestObjectResult>(result);
+        var responseBody = JsonSerializer.Serialize(badRequest.Value);
+        Assert.Equal("\"Invalid signature\"", responseBody);
+        Assert.DoesNotContain(WebhookSecret, responseBody, StringComparison.Ordinal);
+        Assert.Empty(_supabaseRequests);
+        AssertNoSensitiveData(logger.Entries);
+    }
+
+    private static void AssertNoSensitiveData(IReadOnlyCollection<string> entries)
+    {
+        Assert.NotEmpty(entries);
+        foreach (var entry in entries)
+        {
+            // Not the address, not a masked form of it (j***@domain), not the domain on its own.
+            Assert.DoesNotContain("@", entry, StringComparison.Ordinal);
+            Assert.DoesNotContain("jane.private", entry, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain("janes-family-domain", entry, StringComparison.OrdinalIgnoreCase);
+            Assert.DoesNotContain(WebhookSecret, entry, StringComparison.Ordinal);
+            Assert.DoesNotContain(SupabaseKey, entry, StringComparison.Ordinal);
+        }
+    }
+
+    private static string CheckoutCompletedEvent() => JsonSerializer.Serialize(new Dictionary<string, object?>
+    {
+        ["id"] = "evt_test_checkout",
+        ["object"] = "event",
+        ["api_version"] = StripeConfiguration.ApiVersion,
+        ["created"] = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+        ["livemode"] = false,
+        ["pending_webhooks"] = 1,
+        ["type"] = EventTypes.CheckoutSessionCompleted,
+        ["request"] = new Dictionary<string, object?> { ["id"] = null, ["idempotency_key"] = null },
+        ["data"] = new Dictionary<string, object?>
+        {
+            ["object"] = new Dictionary<string, object?>
+            {
+                ["id"] = "cs_test_session",
+                ["object"] = "checkout.session",
+                ["mode"] = "subscription",
+                ["status"] = "complete",
+                ["customer"] = CustomerId,
+                ["customer_email"] = CustomerEmail,
+                ["customer_details"] = new Dictionary<string, object?> { ["email"] = CustomerEmail },
+                ["subscription"] = "sub_TEST456"
+            }
+        }
+    });
+
+    private static HttpRequest SignedRequest(string payload, string signingSecret = WebhookSecret)
+    {
+        var timestamp = DateTimeOffset.UtcNow.ToUnixTimeSeconds();
+        using var hmac = new HMACSHA256(Encoding.UTF8.GetBytes(signingSecret));
+        var signature = Convert.ToHexString(hmac.ComputeHash(Encoding.UTF8.GetBytes($"{timestamp}.{payload}")))
+            .ToLowerInvariant();
+
+        var context = new DefaultHttpContext();
+        context.Request.Method = "POST";
+        context.Request.Body = new MemoryStream(Encoding.UTF8.GetBytes(payload));
+        context.Request.Headers["Stripe-Signature"] = $"t={timestamp},v1={signature}";
+        return context.Request;
+    }
+
+    /// <summary>Records every rendered message, structured value and exception the function logs.</summary>
+    private sealed class CapturingLogger<T> : ILogger<T>
+    {
+        private readonly ConcurrentQueue<string> _entries = new();
+
+        public IReadOnlyCollection<string> Entries => _entries.ToArray();
+
+        public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+        public bool IsEnabled(LogLevel logLevel) => true;
+
+        public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+            Func<TState, Exception?, string> formatter)
+        {
+            var values = state is IEnumerable<KeyValuePair<string, object?>> pairs
+                ? string.Join(" | ", pairs.Select(p => $"{p.Key}={p.Value}"))
+                : string.Empty;
+            _entries.Enqueue($"{logLevel}: {formatter(state, exception)} [{values}] {exception}");
+        }
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/Security/LogSanitizerTests.cs
+++ b/tests/AiDotNet.Serving.Tests/Security/LogSanitizerTests.cs
@@ -1,0 +1,95 @@
+using System.Collections.Concurrent;
+using System.Net;
+using AiDotNet.Serving.Security;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace AiDotNet.Serving.Tests.Security;
+
+public class LogSanitizerTests
+{
+    [Theory]
+    [InlineData("model\r\n[CRIT] forged", @"model\r\n[CRIT] forged")]
+    [InlineData("a\nb", @"a\nb")]
+    [InlineData("a\rb", @"a\rb")]
+    [InlineData("a\tb", @"a\tb")]
+    [InlineData("a\u0085b", @"a\u0085b")] // NEL
+    [InlineData("a\u2028b\u2029c", @"a\u2028b\u2029c")] // line / paragraph separator
+    [InlineData("a\u001B[31mb", @"a\u001B[31mb")] // ANSI escape sequence
+    [InlineData("a\0b", @"a\u0000b")]
+    [InlineData("admin\u202Egnp.exe", @"admin\u202Egnp.exe")] // right-to-left override
+    public void Sanitize_EscapesLineBreaksAndControlCharacters(string raw, string expected)
+    {
+        var sanitized = LogSanitizer.Sanitize(raw);
+
+        Assert.Equal(expected, sanitized);
+        Assert.DoesNotContain('\r', sanitized!);
+        Assert.DoesNotContain('\n', sanitized!);
+    }
+
+    [Theory]
+    [InlineData("resnet-50")]
+    [InlineData("models/sub dir/model_v2.aidn")]
+    [InlineData("modèle-日本語")]
+    [InlineData("")]
+    public void Sanitize_LeavesPrintableTextUnchanged(string raw)
+    {
+        var sanitized = LogSanitizer.Sanitize(raw);
+
+        Assert.Same(raw, sanitized);
+    }
+
+    [Fact]
+    public void Sanitize_PassesNullThrough()
+    {
+        Assert.Null(LogSanitizer.Sanitize(null));
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ModelNotFoundLog_WithCrLfInRouteValue_StaysOnOneLine()
+    {
+        var sink = new CapturingLoggerProvider();
+        using var factory = new ServingTestWebApplicationFactory()
+            .WithWebHostBuilder(builder => builder.ConfigureLogging(logging => logging.AddProvider(sink)));
+        using var client = factory.CreateClient();
+
+        const string forged = "ghost\r\n[CRIT] admin password reset for root";
+        var response = await client.GetAsync("/api/models/" + Uri.EscapeDataString(forged));
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        var notFound = sink.Messages.Where(m => m.Contains("not found", StringComparison.Ordinal)
+                                                && m.Contains("ghost", StringComparison.Ordinal)).ToList();
+        Assert.NotEmpty(notFound);
+        foreach (var message in notFound)
+        {
+            Assert.DoesNotContain('\r', message);
+            Assert.DoesNotContain('\n', message);
+            Assert.Contains(@"ghost\r\n[CRIT] admin password reset for root", message, StringComparison.Ordinal);
+        }
+    }
+
+    private sealed class CapturingLoggerProvider : ILoggerProvider
+    {
+        private readonly ConcurrentQueue<string> _messages = new();
+
+        public IReadOnlyCollection<string> Messages => _messages.ToArray();
+
+        public ILogger CreateLogger(string categoryName) => new CapturingLogger(_messages);
+
+        public void Dispose()
+        {
+        }
+
+        private sealed class CapturingLogger(ConcurrentQueue<string> messages) : ILogger
+        {
+            public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
+
+            public bool IsEnabled(LogLevel logLevel) => true;
+
+            public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception,
+                Func<TState, Exception?, string> formatter) => messages.Enqueue(formatter(state, exception));
+        }
+    }
+}

--- a/tests/AiDotNet.Serving.Tests/SqlSandboxTests.cs
+++ b/tests/AiDotNet.Serving.Tests/SqlSandboxTests.cs
@@ -69,6 +69,127 @@ public class SqlSandboxTests : IClassFixture<SqlSandboxTestFactory>
     }
 
     [Fact(Timeout = 60000)]
+    public async Task ExecuteSql_WithSQLiteAttachOfHostDatabase_CannotReadHostData()
+    {
+        // A pre-existing database file on the server (stand-in for Serving's own persistence DB).
+        var hostDb = NewTempPath();
+        try
+        {
+            await using (var setup = new Microsoft.Data.Sqlite.SqliteConnection($"Data Source={hostDb};Pooling=False"))
+            {
+                await setup.OpenAsync();
+                await using var cmd = setup.CreateCommand();
+                cmd.CommandText = "CREATE TABLE secrets (v TEXT); INSERT INTO secrets VALUES ('host-secret-value');";
+                await cmd.ExecuteNonQueryAsync();
+            }
+
+            var request = new SqlExecuteRequest
+            {
+                Dialect = SqlDialect.SQLite,
+                SchemaSql = $"ATTACH DATABASE '{hostDb}' AS host;",
+                Query = "SELECT v FROM host.secrets"
+            };
+
+            var response = await PostAsJsonAsync("/api/program-synthesis/sql/execute", request);
+            var body = await response.Content.ReadAsStringAsync();
+
+            Assert.False(response.IsSuccessStatusCode, body);
+            Assert.DoesNotContain("host-secret-value", body, StringComparison.Ordinal);
+            var result = JsonConvert.DeserializeObject<SqlExecuteResponse>(body, JsonSettings);
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDelete(hostDb);
+        }
+    }
+
+    [Theory(Timeout = 60000)]
+    [InlineData("query-attach")]
+    [InlineData("script-attach-write")]
+    [InlineData("vacuum-into")]
+    public async Task ExecuteSql_WithSQLite_CannotCreateFilesOnHost(string vector)
+    {
+        var target = NewTempPath();
+        try
+        {
+            var request = vector switch
+            {
+                "query-attach" => new SqlExecuteRequest
+                {
+                    Dialect = SqlDialect.SQLite,
+                    Query = $"ATTACH DATABASE '{target}' AS outside"
+                },
+                "script-attach-write" => new SqlExecuteRequest
+                {
+                    Dialect = SqlDialect.SQLite,
+                    SchemaSql = $"ATTACH DATABASE '{target}' AS outside; CREATE TABLE outside.dropped (payload TEXT);",
+                    SeedSql = "INSERT INTO outside.dropped VALUES ('attacker-controlled');",
+                    Query = "SELECT 1"
+                },
+                _ => new SqlExecuteRequest
+                {
+                    Dialect = SqlDialect.SQLite,
+                    SchemaSql = "CREATE TABLE t (payload TEXT); INSERT INTO t VALUES ('attacker-controlled');",
+                    Query = $"VACUUM INTO '{target}'"
+                }
+            };
+
+            var response = await PostAsJsonAsync("/api/program-synthesis/sql/execute", request);
+            var result = await ReadFromJsonAsync<SqlExecuteResponse>(response.Content);
+
+            Assert.False(File.Exists(target), $"{vector}: sandboxed SQL created a file on the host at {target}.");
+            Assert.NotNull(result);
+            Assert.False(result.Success);
+        }
+        finally
+        {
+            TryDelete(target);
+        }
+    }
+
+    [Fact(Timeout = 60000)]
+    public async Task ExecuteSql_WithSQLiteMultiStatementScripts_StillWorks()
+    {
+        var request = new SqlExecuteRequest
+        {
+            Dialect = SqlDialect.SQLite,
+            SchemaSql = "CREATE TABLE a (id INTEGER); CREATE TABLE b (id INTEGER, a_id INTEGER);",
+            SeedSql = "INSERT INTO a VALUES (1); INSERT INTO a VALUES (2); INSERT INTO b VALUES (10, 2);",
+            Query = "WITH j AS (SELECT a.id AS aid, b.id AS bid FROM a JOIN b ON b.a_id = a.id) SELECT aid, bid FROM j"
+        };
+
+        var response = await PostAsJsonAsync("/api/program-synthesis/sql/execute", request);
+        response.EnsureSuccessStatusCode();
+
+        var result = await ReadFromJsonAsync<SqlExecuteResponse>(response.Content);
+        Assert.NotNull(result);
+        Assert.True(result.Success);
+        var row = Assert.Single(result.Rows);
+        Assert.Equal(2, row["aid"].IntegerValue);
+        Assert.Equal(10, row["bid"].IntegerValue);
+    }
+
+    private static string NewTempPath() =>
+        Path.Combine(Path.GetTempPath(), $"aidotnet-sql-escape-{Guid.NewGuid():N}.db");
+
+    private static void TryDelete(string path)
+    {
+        try
+        {
+            if (File.Exists(path))
+            {
+                File.Delete(path);
+            }
+        }
+        catch (IOException)
+        {
+            // Best-effort cleanup of a temp file.
+        }
+    }
+
+    [Fact(Timeout = 60000)]
     public async Task ExecuteSql_WithPostgresWithoutConfiguration_ReturnsBadRequest()
     {
         var request = new SqlExecuteRequest


### PR DESCRIPTION
## Summary

A full-repo CodeQL run (build-mode `none`, which extracts projects the real `codeql` job never compiles) surfaced **91 untriaged security alerts** in `AiDotNet.Serving` and `AiDotNet.Playground.Functions`: 4 × `cs/sql-injection`, 5 × `cs/exposure-of-sensitive-information`, 82 × `cs/log-forging`.

Every one is triaged below with a verdict and a concrete reason. **87 are real and fixed.** The 4 SQL alerts are not injection bugs — running caller-supplied SQL is the endpoint's entire purpose — but reading them closely uncovered a **real SQLite sandbox escape** that is fixed here.

Three commits, one per logical fix:

- `94e417ec9` fix(serving): stop sandboxed sqlite from attaching host database files
- `f47ffbc27` fix(serving): neutralize caller-controlled values before logging them
- `bfc414fc0` fix(playground): stop logging email-derived data in the stripe webhook

---

## Root causes

### 1. SQLite sandbox escape — `src/AiDotNet.Serving/Sandboxing/Sql/SqlSandboxExecutor.cs:635`, `:743`

The SQL sandbox is *designed* to execute SQL the caller writes, so parameterisation and identifier quoting do not apply — they would defeat the feature. The actual defect is that SQLite could leave its private in-memory database:

- `ATTACH DATABASE '<host path>' AS x` reads or creates **any file on the server**, including Serving's own persistence database holding license and API keys.
- `VACUUM INTO '<host path>'` writes a file anywhere the process can write.
- The schema and seed scripts at `:635` accept multiple statements, so a caller could attach, then `CREATE TABLE` and `INSERT` into the attached (host) file.

**Fix:** `ConfineSqliteToPrivateDatabase` sets the sandbox connection's attachable-database limit to **0**. Both vectors now fail with SQLite's own "too many attached databases - max 0". Nothing else about the sandbox changes.

### 2. Log forging — 77 lines across 8 files in `src/AiDotNet.Serving`

Request-controlled values (route `modelName`, route `runId`, body `Name` / `Path` / `TokenizerPath` / `ModelName` / `StripeCustomerId` / `CustomerName`, the LoRA-adapter header, resolved file paths, and `response.Error`) were written into log messages verbatim. A value containing CR/LF injects a forged log line — enough to fake an audit trail.

**Fix:** one shared helper, `src/AiDotNet.Serving/Security/LogSanitizer.cs`, applied at every flagged argument. It escapes control characters (CR, LF, NUL, ESC), Unicode line separators and bidirectional-text controls, and leaves ordinary text untouched. Raw values are still used for lookups and responses — only log output is sanitized.

### 3. Sensitive data in logs — `src/AiDotNet.Playground.Functions/StripeWebhook.cs:122, 161, 182, 302, 341`

`MaskEmail` produced `j***@<full domain>`. The local part is masked but the **domain survives**, and a personal or small-company domain identifies the person — so this is PII in logs, exactly as CodeQL says.

**Fix:** log the Stripe customer / session / subscription IDs and the Supabase user ID instead; `MaskEmail` is removed. Responses never echoed secrets (they are the constant `"Invalid signature"` or a bare status code), and that is now covered by a test.

---

## Full per-alert triage

### `cs/sql-injection` (4)

| Location | Verdict | Reason | Action |
|---|---|---|---|
| `SqlSandboxExecutor.cs:635` (schema/seed scripts) | **Not injection — but hid a real escape** | Executing the caller's script is the feature. The bug is that SQLite could `ATTACH` a host file and write to it | Attach cap = 0, + tests |
| `SqlSandboxExecutor.cs:743` (SQLite command) | **Not injection — but hid a real escape** | Same sink, same escape via `ATTACH` / `VACUUM INTO` as the query itself | Same fix |
| `SqlSandboxExecutor.cs:746` (Postgres command) | **False positive** | Executing caller SQL is the purpose. With the Docker fallback each request gets its own container; with a configured connection string the operator has deliberately granted that credential | No code change; trust boundary documented in `ServingSqlSandboxOptions` |
| `SqlSandboxExecutor.cs:749` (MySQL command) | **False positive** | As `:746` | Same |

> **These 4 alerts will keep firing after this PR merges.** The sinks are intentional — the endpoint exists to run user SQL — so there is nothing to "fix" that would not delete the feature. **They need dismissing in the code-scanning UI** (as "used in tests"/"false positive" per your convention). Nothing is suppressed in code by this PR, deliberately: a code-level suppression would hide the sink from future review.

### `cs/exposure-of-sensitive-information` (5)

| Location | Verdict | Reason | Action |
|---|---|---|---|
| `StripeWebhook.cs:122` | **Real** | Masked email still logs the full domain → identifies the user | Log Stripe/Supabase IDs |
| `StripeWebhook.cs:161` | **Real** | Same | Same |
| `StripeWebhook.cs:182` | **Real** | Same | Same |
| `StripeWebhook.cs:302` | **Real** | Same | Same |
| `StripeWebhook.cs:341` | **Real** | Same | Same |

### `cs/log-forging` (82)

All 82 are real: each sink receives a request-controlled string with no neutralisation, and every one is fixed with `LogSanitizer.Sanitize(...)`.

| File | Lines | Alerts | Tainted source | Verdict |
|---|---|---:|---|---|
| `Controllers/EmbeddingsController.cs` | 60, 72, 78, 111, 117, 144, 156, 162, 195, 201, 228, 245, 251, 286, 292, 319, 336, 342, 378, 384 | 20 | route `modelName` | Real → sanitized |
| `Controllers/ModelsController.cs` | 96 (×2), 120, 144, 155, 177 (×2), 186 (×2), 207, 213 (×2), 220 (×2), 232, 241, 250, 259, 268, 304, 309, 328, 333, 340, 386, 434, 534 | 27 | body `Name` / `Path` / `TokenizerPath`, resolved path (`GetFullPath` preserves line breaks), route `modelName` | Real → sanitized |
| `Controllers/InferenceController.cs` | 75, 91, 99, 108, 192, 198, 203, 208, 221, 343, 360, 384, 390, 396, 439, 458, 496 | 17 | route `modelName`, variant name built from the LoRA-adapter header, body `ModelName`, `response.Error` | Real → sanitized |
| `Controllers/FederatedController.cs` | 86, 111, 136, 179, 184, 234, 239, 264, 284 | 9 | route `runId` (a string, not a GUID) | Real → sanitized |
| `Security/Licensing/StripeService.cs` | 117, 408, 417, 432 | 4 | customer ID from the request body | Real → sanitized |
| `Services/TextGenerationService.cs` | 286, 295, 347 | 3 | route `modelName` | Real → sanitized |
| `Controllers/StripeController.cs` | 87 | 1 | body `StripeCustomerId` (`userId` sanitized alongside) | Real → sanitized |
| `Security/Licensing/LicenseService.cs` | 90 | 1 | `CustomerName` from an admin request body | Real, lower risk → sanitized |

**Totals:** 87 real and fixed (82 log-forging + 5 exposure), 2 alerts whose sink is intentional but which exposed a real escape that is fixed, 2 pure false positives.

---

## Evidence

### Fails before / passes after

Each fix was reverted in isolation, rebuilt, and the new tests re-run:

| Fix | Before | After |
|---|---|---|
| SQLite attach cap | **4 of 7 SQL tests fail** — three report "sandboxed SQL created a file on the host", and the host-database read returns the planted secret | 7 / 7 pass |
| Log sanitizer | **fails** — a CR/LF model name sent to `GET /api/models/{name}` puts a literal `\r` into the log line | passes |
| Stripe webhook | **2 of 3 fail** — logs contain `email j***@janes-family-domain.` | 3 / 3 pass |

The invalid-signature test passes both before and after; it is a regression guard, not a demonstration.

### Test counts

| Suite | Result |
|---|---|
| `AiDotNet.Serving.Tests` (full suite) | **309 passed, 0 failed** — 18 of those test cases are new (7 new test methods; `[Theory]` rows account for the rest) |
| `AiDotNet.Playground.Functions.Tests` (new project) | **3 passed** |

### CodeQL before/after

CodeQL CLI 2.27.0, buildless extraction scoped to Serving + Playground, running the log-forging, SQL-injection and exposure queries:

| | `cs/log-forging` | `cs/exposure-of-sensitive-information` |
|---|---:|---:|
| `master` | 83 | 5 |
| this branch | **0** | **0** |

(The scoped run reports 83 rather than 82 log-forging results because it does not compile the core library, which slightly changes what the extractor resolves; the same run cannot reproduce the 4 SQL alerts for the same reason. A full-repo run — which PR #C enables in CI — will still report the 4 intentional SQL sinks.)

---

## Blast radius / file map

**16 files changed, +637 / −104.**

| File | +/− | Change |
|---|---|---|
| `src/AiDotNet.Serving/Security/LogSanitizer.cs` | +52 | **New.** The single sanitization helper |
| `src/AiDotNet.Serving/Sandboxing/Sql/SqlSandboxExecutor.cs` | +18 / −0 | Attach cap on the sandbox connection |
| `src/AiDotNet.Serving/Configuration/ServingSqlSandboxOptions.cs` | +24 / −0 | Documents the Postgres/MySQL trust boundary |
| `src/AiDotNet.Serving/Controllers/ModelsController.cs` | +22 / −22 | Log arguments wrapped |
| `src/AiDotNet.Serving/Controllers/EmbeddingsController.cs` | +21 / −20 | Log arguments wrapped |
| `src/AiDotNet.Serving/Controllers/InferenceController.cs` | +18 / −17 | Log arguments wrapped |
| `src/AiDotNet.Serving/Controllers/FederatedController.cs` | +9 / −9 | Log arguments wrapped |
| `src/AiDotNet.Serving/Security/Licensing/StripeService.cs` | +4 / −4 | Log arguments wrapped |
| `src/AiDotNet.Serving/Services/TextGenerationService.cs` | +4 / −3 | Log arguments wrapped |
| `src/AiDotNet.Serving/Controllers/StripeController.cs` | +2 / −1 | Log arguments wrapped |
| `src/AiDotNet.Serving/Security/Licensing/LicenseService.cs` | +1 / −1 | Log argument wrapped |
| `src/AiDotNet.Playground.Functions/StripeWebhook.cs` | +14 / −27 | Log IDs instead of emails; `MaskEmail` removed |
| `tests/AiDotNet.Serving.Tests/SqlSandboxTests.cs` | +121 | Sandbox-escape tests |
| `tests/AiDotNet.Serving.Tests/Security/LogSanitizerTests.cs` | +95 | **New** |
| `tests/AiDotNet.Playground.Functions.Tests/**` | +232 | **New project**: webhook logging tests |

The controller changes are mechanical — the value passed to the logger is wrapped, nothing else moves. Risk concentrates in `SqlSandboxExecutor.cs`: the attach cap is applied to the sandbox connection only, and the 7 sandbox tests cover both the escape and ordinary queries still working.

---

## Relationship to the CodeQL-coverage PR (companion PR "C")

These alerts exist because the real `codeql` job compiles only `src/AiDotNet.csproj`, so **neither of these projects has ever been analysed in CI**. The companion PR adds them to the traced build, which is what will keep this class of finding from going unnoticed again.

Two cross-cutting notes:

1. **`tests/AiDotNet.Playground.Functions.Tests` is not in `AiDotNet.sln` or any CI job yet.** It cannot be wired up on this branch: `AiDotNet.Playground.Functions` still references the AiDotNet **package** here, and an existing test project cannot reference it without two AiDotNet assemblies colliding. Once the companion PR switches Playground to a project reference, a small follow-up should add this project to the solution and to the test workflow. I deliberately did not do that wiring on either branch — on this one it would not build, and on the other the project does not exist.
2. Once both merge, the full-repo CodeQL run will confirm 0 log-forging and 0 exposure alerts in CI rather than only locally.

---

## What this does not do

- **Does not dismiss the 4 intentional SQL sinks.** They will still appear in code scanning and need a decision in the UI. No in-code suppression was added.
- **Does not restrict what SQL the sandbox accepts.** Parameterising or quoting would delete the feature. Only the SQLite file-system escape is closed.
- **Does not add an execution time limit to the SQLite sandbox.** `CommandTimeout` does not interrupt a running SQLite statement, so a recursive CTE still runs until the client disconnects. Fixing that needs an SQLite progress-handler callback with a deadline — a separate change.
- **Does not isolate the Postgres sandbox.** With a configured connection string the scripts can issue `COMMIT`, and the per-request schema is a naming convention, not isolation. Now documented; real isolation is your call.
- **Does not change any response body.** Only log output and the SQLite connection configuration change.
- **Does not wire the new Playground test project into the solution or CI** — see the cross-reference above.
- **Does not touch the other findings spotted nearby:** `ApplyLimit` wraps queries as `SELECT * FROM (<sql>) AS aidotnet_q LIMIT n`, so a query ending in a `--` comment fails to parse; `NormalizeSingleStatement` rejects a `;` even inside a string literal; the webhook still logs the Supabase error body in full with no length cap, sets the global `StripeConfiguration.ApiKey` per request, and pages through every Supabase user to find one email.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
