### PR TITLE
ci(codeql): analyze AiDotNet.Serving and Playground.Functions in the traced build

### DIFF
--- a/.github/workflows/azure-functions-deploy.yml
+++ b/.github/workflows/azure-functions-deploy.yml
@@ -23,7 +23,11 @@ jobs:
   build-and-deploy:
     name: Build and Deploy
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    # The functions project references src/AiDotNet.csproj, so this build compiles the library's
+    # net10.0 target too (about 6.5 minutes on a 128-core workstation; several times that on a
+    # 4-core hosted runner, where CodeQL's traced net10.0 build of it takes about 26 minutes).
+    # 15 minutes was sized for restoring a prebuilt AiDotNet package.
+    timeout-minutes: 45
 
     steps:
       - name: Checkout code

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -181,8 +181,11 @@ jobs:
     # The traced net10 build takes about 31 minutes on generated-source-heavy PRs. The #2032
     # analysis was still running when the 60-minute ceiling cancelled it, while master's #2026
     # baseline completed in 57:48. Give extraction, SARIF generation, and upload enough margin
-    # for normal hosted-runner variance without hiding a genuinely hung job.
-    timeout-minutes: 75
+    # for normal hosted-runner variance without hiding a genuinely hung job. Recent PR runs took
+    # 66-71 minutes (about 26 traced build + 31 analysis), and the job now also traces Serving and
+    # the playground functions (about 40 s of untraced local compile, under 1% more source), so the
+    # ceiling moves from 75 to 85 minutes to keep the same margin.
+    timeout-minutes: 85
     # CodeQL remains mandatory even for non-runtime changes because the active Main ruleset
     # requires a CodeQL result for the candidate commit. This is one job, not a model/test matrix.
     if: "${{ always() && !cancelled() && fromJSON(needs.validation-source.outputs.execute_quality) && (github.event.pull_request.draft != true) && !startsWith(github.head_ref, 'release-please--') && !(github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(master): release')) }}"
@@ -227,7 +230,10 @@ jobs:
             nuget-${{ runner.os }}-
 
       - name: Restore dependencies
-        run: dotnet restore src/AiDotNet.csproj
+        run: |
+          dotnet restore src/AiDotNet.csproj
+          dotnet restore src/AiDotNet.Serving/AiDotNet.Serving.csproj
+          dotnet restore src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4
@@ -236,10 +242,19 @@ jobs:
           config-file: ./.github/codeql/codeql-config.yml
           queries: security-and-quality
 
-      # CodeQL needs to trace the build - can't reuse artifacts
-      # Build only the main library to avoid file lock issues with AiDotNet.Serving's static web assets
+      # CodeQL needs to trace the build - can't reuse artifacts.
+      # CodeQL only analyzes what the traced build compiles, so every shipped entry point that
+      # takes untrusted input has to be built here: the core library, the Serving API and the
+      # playground's Azure Functions. This step used to build the library alone to avoid a file
+      # lock on AiDotNet.Serving's static web assets; naming each project in its own sequential
+      # command (the pattern the build job uses) builds Serving exactly once, never concurrently.
+      # The core library's command is unchanged and runs first, so its extraction is identical;
+      # the next two builds find it up to date and compile only their own sources.
       - name: Build for CodeQL (net10.0)
-        run: dotnet build src/AiDotNet.csproj -c Release --no-restore -f net10.0
+        run: |
+          dotnet build src/AiDotNet.csproj -c Release --no-restore -f net10.0
+          dotnet build src/AiDotNet.Serving/AiDotNet.Serving.csproj -c Release --no-restore
+          dotnet build src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj -c Release --no-restore
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- AiDotNet ecosystem -->
-    <PackageVersion Include="AiDotNet" Version="0.113.0" />
     <!-- AiDotNet.Tensors 0.86.1 â€” bumped from 0.84.1 to unblock this PR (#1417).
          The dep that gated this PR's INT8 wiring shipped: Tensors PR #427
          (SgemmWithInt8RowScaledCachedB â€” per-row-scaled INT8 weight-only GEMM)

--- a/src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj
+++ b/src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj
@@ -22,9 +22,14 @@
     <PackageReference Include="Stripe.net" />
   </ItemGroup>
 
-  <!-- AiDotNet packages for runtime code execution -->
+  <!-- AiDotNet for runtime code execution. A project reference, like every other in-repo consumer
+       (Serving, Dashboard, the Storage satellites, the tests and tools), so the playground compiles
+       and runs the library at this commit. It used to be a PackageReference pinned in
+       Directory.Packages.props; that pin stayed at 0.113.0 while the library moved on, so the
+       playground served an old API and its AiDotNet.Tensors dependency collided with the in-repo
+       Tensors assembly when CodeQL extracted the repository. -->
   <ItemGroup>
-    <PackageReference Include="AiDotNet" />
+    <ProjectReference Include="..\AiDotNet.csproj" />
   </ItemGroup>
 
 </Project>

--- a/tools/TestImpact/Test-CiImpactWorkflow.ps1
+++ b/tools/TestImpact/Test-CiImpactWorkflow.ps1
@@ -167,6 +167,23 @@ Assert-Contract (-not $codeqlHeader.Contains(
 Assert-Contract ($codeqlHeader.Contains('always()') -and $codeqlHeader.Contains('!cancelled()')) `
     'CodeQL cannot publish its required result after a selector failure'
 
+# CodeQL analyzes only what the traced build compiles. A project dropped from this step silently
+# disappears from code scanning instead of failing, which is how the Serving API and the
+# playground functions went unanalyzed. Every build must also be restored first (--no-restore).
+$codeqlBuild = Get-StepBlock -JobBlock $codeqlJob -Step 'Build for CodeQL (net10.0)'
+$codeqlRestore = Get-StepBlock -JobBlock $codeqlJob -Step 'Restore dependencies'
+Assert-Contract ([bool] $codeqlBuild) 'CodeQL has no traced build step'
+foreach ($codeqlProject in @(
+        'src/AiDotNet.csproj -c Release --no-restore -f net10.0',
+        'src/AiDotNet.Serving/AiDotNet.Serving.csproj -c Release --no-restore',
+        'src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj -c Release --no-restore')) {
+    Assert-Contract ($codeqlBuild.Contains("dotnet build $codeqlProject")) `
+        "CodeQL's traced build does not compile '$codeqlProject'"
+    $projectPath = $codeqlProject.Split(' ')[0]
+    Assert-Contract ($codeqlRestore.Contains("dotnet restore $projectPath")) `
+        "CodeQL builds '$projectPath' with --no-restore but never restores it"
+}
+
 # Every Sonar step parses this value with fromJSON. It must therefore be defined on the Sonar job,
 # not on a neighboring job where it is invisible and becomes a null template value at runtime.
 $sonarJob = Get-JobBlock -WorkflowText $validation -Job 'sonarcloud'


### PR DESCRIPTION
## Summary

The `codeql` job traces a build of `src/AiDotNet.csproj` **only**, and CodeQL analyses exactly what the traced build compiles. `AiDotNet.Serving` (the HTTP API) and `AiDotNet.Playground.Functions` (the public Azure Functions endpoint) have therefore **never been analysed in CI** — both are shipped entry points that take untrusted input.

This PR adds both to the traced build, leaving the core library's build command and analysis byte-for-byte unchanged, and fixes the stale package pin that made Playground.Functions unanalysable in the first place.

Two commits:

- `bf05125b5` fix(playground): reference AiDotNet by project instead of the 0.113.0 package
- `492c7dc74` ci(codeql): trace AiDotNet.Serving and Playground.Functions builds

---

## Root causes

### 1. Nothing compiled Serving or Playground under CodeQL — `.github/workflows/sonarcloud.yml:241-242`

```yaml
- name: Build for CodeQL (net10.0)
  run: dotnet build src/AiDotNet.csproj -c Release --no-restore -f net10.0
```

The comment above it explained the narrowing as avoiding "file lock issues with AiDotNet.Serving's static web assets". `.github/codeql/codeql-config.yml` excludes neither project — its `paths-ignore` covers only tests, examples and docs — so the build step was the only gap.

### 2. Stale package pin — `src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj:27` and `Directory.Packages.props:7`

Playground.Functions was the **only** in-repo consumer using a `PackageReference` to `AiDotNet`, pinned to **0.113.0** while the current release is **0.231.0** — 118 releases behind. That package pulls `AiDotNet.Tensors` 0.9.1, whose assembly version matches the current Tensors, and that collision is what broke buildless extraction.

---

## Reference decision: project reference to `src/AiDotNet.csproj`

**Evidence gathered before changing it:**

| Question | Finding |
|---|---|
| How do other in-repo consumers reference AiDotNet? | **All of them use a project reference**: `AiDotNet.Serving`, `AiDotNet.Dashboard`, `AiDotNet.Privacy.HE`, every `AiDotNet.Storage.*`, the test projects, `AiDotNetBenchmarkTests`, and all of `tools/` |
| Is there a documented reason for the pin? | **No.** No README in the project, no comment in the csproj, and `git log` on the csproj shows no rationale |
| Where did the pin come from? | The central `PackageVersion` entry dates from #926 (the move to central package management) and was never bumped again — it looks like drift, not a decision |
| What does the pin cost? | The playground runs user code against whatever library it references, so it has been demonstrating an API 118 releases old |
| Does the switch build? | **Yes, with no source changes**: 0 warnings, 0 errors, and a single `AiDotNet.Tensors` 1.0.0.0 in the output |

The now-unused `AiDotNet` `PackageVersion` line is removed from `Directory.Packages.props`.

---

## The workflow change

- **Restore** — now restores all three projects instead of only the core library.
- **Build** — the core library's command is unchanged and still runs first; Serving and then Playground.Functions follow, **one project per command**. Building them sequentially (the pattern the `build` job already uses) means Serving is compiled exactly once and never alongside another build, which is what the original file-lock comment was protecting against.
- **Core analysis is unchanged** — verified from a normal-verbosity build log: the Serving build finds the core library up to date and skips its compile, so the core is compiled, and therefore extracted, exactly once, as before.

## Timeout changes

| Workflow | Before | After | Why |
|---|---:|---:|---|
| `sonarcloud.yml` → `codeql` job | 75 min | **85 min** | Recent runs already take 66–71 min (~26 min traced build + ~31 min analysis). Adding two projects to the traced build eats the remaining margin; 85 keeps the same headroom without hiding a genuinely hung job |
| `azure-functions-deploy.yml` | 15 min | **45 min** | The deploy now compiles the library's net10.0 target instead of restoring a prebuilt package. The old ceiling was sized for the package restore and would likely time out |

---

## Measured build cost

Plain `dotnet build -c Release` (untraced) on a 128-core workstation:

| Step | Time |
|---|---:|
| Restore — core / Serving / Playground | 13.4 s / 6.1 s / 8.3 s |
| Core library, net10.0 (unchanged, for scale) | 379.9 s |
| **Serving** (first build, core already built) | **18.5 s** |
| Serving (rebuild) | 12.0 s |
| **Playground.Functions** (first build, core already built) | **21.5 s** |

**Extra cost: ~40 s of untraced compile locally.** Under CodeQL tracing on a 4-core hosted runner, expect a couple of minutes. The analysis step should grow only slightly: the two projects add ~19.9k lines to ~2.27M lines of source, under 1%.

---

## Contract test

`tools/TestImpact/Test-CiImpactWorkflow.ps1` asserted nothing about the codeql job's build step, so a regression here would have been invisible. It now fails if the traced build stops compiling any of the three projects, or builds one with `--no-restore` without restoring it first.

| Run | Result |
|---|---|
| `pwsh -NoProfile -File tools/TestImpact/Test-CiImpactWorkflow.ps1` on this branch | **exit 0** — `CI impact workflow contract passed (10 expensive jobs gated).` |
| Same script against `master`'s `sonarcloud.yml` | **exit 1** — 4 failures: Serving and Playground are neither compiled nor restored |

---

## Before/after evidence

| | Before | After |
|---|---|---|
| Projects compiled by the traced CodeQL build | 1 (`src/AiDotNet.csproj`) | 3 (+ Serving, + Playground.Functions) |
| Serving / Playground alerts visible in CI | **none — never analysed** | analysed every run |
| Playground.Functions build | AiDotNet 0.113.0 (118 releases stale), breaks buildless extraction | current library, 0 warnings / 0 errors |
| Contract coverage of the codeql build step | none | asserted, fails on `master`'s workflow |

What the *full-repo* run finds once this merges is already quantified in companion PR "B": on `master` that scope reports 83 `cs/log-forging` + 5 `cs/exposure-of-sensitive-information` + 4 `cs/sql-injection`; with B merged, 0 / 0 / 4 (those 4 SQL sinks are intentional and need dismissing in the code-scanning UI).

**Not yet run in CI:** the traced build with these three commands has only been validated as a local untraced build plus the contract test. The first run on this PR is the real proof, and the 85-minute ceiling is the number to watch.

---

## Blast radius / file map

**5 files changed, +50 / −10.** No library or application source is touched.

| File | +/− | Change |
|---|---|---|
| `.github/workflows/sonarcloud.yml` | +21 / −6 | Restore + build all three projects; timeout 75 → 85 min |
| `tools/TestImpact/Test-CiImpactWorkflow.ps1` | +17 / −0 | Contract check for the codeql build step |
| `src/AiDotNet.Playground.Functions/AiDotNet.Playground.Functions.csproj` | +7 / −2 | Package reference → project reference |
| `.github/workflows/azure-functions-deploy.yml` | +5 / −1 | Timeout 15 → 45 min |
| `Directory.Packages.props` | +0 / −1 | Drop the now-unused `AiDotNet` `PackageVersion` |

Blast radius is CI and one csproj. The riskiest item is the Playground deploy workflow, which now builds the library from source — hence the raised timeout.

---

## Relationship to the security PR (companion PR "B")

B fixes the alerts this PR makes visible; this PR keeps them visible. Two notes:

1. **B adds `tests/AiDotNet.Playground.Functions.Tests`, which is not in `AiDotNet.sln` or any CI job.** Wiring it up needs *this* PR's project-reference change (with B's package pin, a test project cannot reference Playground.Functions without two AiDotNet assemblies colliding) **and** B's branch, where the project actually exists. It is therefore not possible on either branch alone, and I did not fake it: referencing a path that does not exist on this branch would break this branch's own build. **Follow-up once both merge:** add that project to `AiDotNet.sln` and to the test workflow.
2. Merge order does not matter for correctness. If this merges first, CodeQL starts reporting B's 87 real alerts on subsequent PRs until B lands.

---

## What this does not do

- **Does not change the core library's CodeQL analysis.** Same command, same position, same extraction — verified from a build log.
- **Does not change which queries run** (`security-and-quality`) or edit `.github/codeql/codeql-config.yml`.
- **Does not add the other unanalysed projects** — `AiDotNet.Dashboard`, `AiDotNet.Storage.*` and `AiDotNet.Privacy.HE` are still outside the traced build. Adding them is the same one-line pattern, but each costs build time in the longest CI job and none of them was in scope here.
- **Does not fix any alert.** That is companion PR "B".
- **Does not wire the new Playground test project into the solution or CI** — see above.
- **Does not make the Playground redeploy when only the library changes.** Its deploy still triggers on `src/AiDotNet.Playground.Functions/**` only; adding library paths would deploy to production on every library commit, which is your call to make.
- **Does not touch `deploy-serving.yml`**, whose path trigger watches `src/AiDotNet/**` — a directory that does not appear to exist, so that trigger looks dead. Flagged, not changed.
- **Does not silence Serving's existing 11 build warnings**, which are present on `master` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
