### PR TITLE
fix(video): declared-shape predict for 20 video models and videomae pretraining fidelity

### DIFF
--- a/src/Video/ActionRecognition/TimeSformer.cs
+++ b/src/Video/ActionRecognition/TimeSformer.cs
@@ -154,19 +154,6 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
     #region Constructors
 
     /// <summary>
-    /// Creates a TimeSformer model using native layers for training and inference.
-    /// </summary>
-    /// <param name="architecture">Architecture for the video encoder.</param>
-    /// <param name="numClasses">Number of output classes for classification.</param>
-    /// <param name="optimizer">Optional optimizer for training. Default: Adam.</param>
-    /// <param name="lossFunction">Optional loss function. Default: CrossEntropy.</param>
-    /// <param name="embedDim">Embedding dimension (default: 768).</param>
-    /// <param name="numHeads">Number of attention heads (default: 12).</param>
-    /// <param name="numLayers">Number of transformer layers (default: 12).</param>
-    /// <param name="numFrames">Number of frames to process (default: 8).</param>
-    /// <param name="patchSize">Patch size for tokenization (default: 16).</param>
-    /// <param name="attentionType">Type of space-time attention (default: DividedSpaceTime).</param>
-    /// <summary>
     /// Initializes a new instance with default architecture settings (8-frame 224x224 RGB clips, 400 classes).
     /// </summary>
     /// <remarks>
@@ -186,6 +173,24 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
     {
     }
 
+    /// <summary>
+    /// Creates a TimeSformer model using native layers for training and inference.
+    /// </summary>
+    /// <param name="architecture">Architecture for the video encoder.</param>
+    /// <param name="numClasses">Number of output classes for classification.</param>
+    /// <param name="optimizer">Optional optimizer for training. Default: Adam.</param>
+    /// <param name="lossFunction">Optional loss function. Default: CrossEntropy.</param>
+    /// <param name="embedDim">Embedding dimension (default: 768).</param>
+    /// <param name="numHeads">Number of attention heads (default: 12).</param>
+    /// <param name="numLayers">Number of transformer layers (default: 12).</param>
+    /// <param name="numFrames">Number of frames per clip (default: 8). When the architecture declares a
+    /// frame count (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) that count is used, as for
+    /// VideoMAE; passing a different non-default value throws, since the two would describe different
+    /// clips. The frame count sizes the positional table and is the group size the divided space-time
+    /// blocks fall back to when they are run without an explicit frame count.</param>
+    /// <param name="patchSize">Patch size for tokenization (default: 16).</param>
+    /// <param name="attentionType">Type of space-time attention (default: DividedSpaceTime).</param>
+    /// <param name="options">Optional configuration options.</param>
     public TimeSformer(
         NeuralNetworkArchitecture<T> architecture,
         int numClasses = 400,
@@ -220,7 +225,7 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         _embedDim = embedDim;
         _numHeads = numHeads;
         _numLayers = numLayers;
-        _numFrames = numFrames;
+        _numFrames = VideoClipFrameCount.Resolve(architecture, numFrames, DefaultNumFrames);
         _patchSize = patchSize;
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _numClasses = numClasses;
@@ -260,7 +265,7 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         _embedDim = embedDim;
         _numHeads = 12;
         _numLayers = 12;
-        _numFrames = 8;
+        _numFrames = VideoClipFrameCount.Resolve(architecture, DefaultNumFrames, DefaultNumFrames);
         _patchSize = 16;
         _imageSize = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _numClasses = numClasses;
@@ -293,14 +298,28 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         if (videoFrames is null)
             throw new ArgumentNullException(nameof(videoFrames));
 
-        if (_useNativeMode)
-        {
-            return Forward(videoFrames);
-        }
-        else
+        if (!_useNativeMode)
         {
             return PredictOnnx(videoFrames);
         }
+
+        var probabilities = Forward(videoFrames);
+
+        // Unbatched in, unbatched out. TokenizeVideo treats a [T, C, H, W] clip (or a single [C, H, W]
+        // frame) as a batch of one, so the head emits [1, NumClasses]. This method documents
+        // [NumClasses] for that input, the model's output layout is batch-optional, and the base
+        // PredictCore squeezes the unit batch it adds - so return the unbatched vector here too. Only
+        // the tokenized path is squeezed: a caller-supplied layer stack receives the input unchanged, so
+        // its leading axis is whatever the caller gave it.
+        if (_usesTokenizedNativePath
+            && videoFrames.Rank < 5
+            && probabilities.Rank == 2
+            && probabilities.Shape[0] == 1)
+        {
+            return probabilities.Reshape([probabilities.Shape[1]]);
+        }
+
+        return probabilities;
     }
 
     /// <summary>
@@ -398,31 +417,15 @@ public partial class TimeSformer<T> : NeuralNetworkBase<T>
         return new Tensor<T>(outputShape, new Vector<T>(outputData));
     }
 
-    private Tensor<T> Softmax(Tensor<T> logits)
-    {
-        var result = new Tensor<T>(logits._shape);
-        double maxVal = double.MinValue;
-
-        for (int i = 0; i < logits.Length; i++)
-        {
-            double val = Convert.ToDouble(logits.Data.Span[i]);
-            if (val > maxVal) maxVal = val;
-        }
-
-        double sum = 0;
-        for (int i = 0; i < logits.Length; i++)
-        {
-            sum += Math.Exp(Convert.ToDouble(logits.Data.Span[i]) - maxVal);
-        }
-
-        for (int i = 0; i < logits.Length; i++)
-        {
-            double prob = Math.Exp(Convert.ToDouble(logits.Data.Span[i]) - maxVal) / sum;
-            result.Data.Span[i] = NumOps.FromDouble(prob);
-        }
-
-        return result;
-    }
+    /// <summary>
+    /// Softmax over the class axis (the last one), independently for every clip in the batch.
+    /// </summary>
+    /// <remarks>
+    /// This used to normalise over EVERY element of the logits tensor, so for a batch of B clips the
+    /// B x NumClasses probabilities summed to 1 in total instead of 1 per clip: each clip's
+    /// "probabilities" were scaled by how confident the other clips in the batch happened to be.
+    /// </remarks>
+    private Tensor<T> Softmax(Tensor<T> logits) => Engine.Softmax(logits);
 
     /// <inheritdoc/>
     protected override Tensor<T> PredictCore(Tensor<T> input)

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -265,26 +265,11 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// ignored it and always used <c>numFrames</c> (default 16), so an architecture declaring 8-frame
     /// clips produced a model reporting and masking for 16. An explicit <c>numFrames</c> that disagrees
     /// with the declared count is rejected rather than silently overridden. The parameter's default
-    /// value cannot be told apart from an explicit 16, so it defers to the architecture.
+    /// value cannot be told apart from an explicit 16, so it defers to the architecture. The rule lives
+    /// in <see cref="VideoClipFrameCount"/>, shared with TimeSformer.
     /// </remarks>
     private static int ResolveNumFrames(NeuralNetworkArchitecture<T> architecture, int numFrames)
-    {
-        int declared = architecture.InputFrames;
-        if (declared <= 0)
-        {
-            return numFrames;
-        }
-
-        if (numFrames != declared && numFrames != DefaultNumFrames)
-        {
-            throw new ArgumentException(
-                $"numFrames ({numFrames}) conflicts with the architecture's declared InputFrames ({declared}). " +
-                "Pass the same value, or omit numFrames to use the architecture's frame count.",
-                nameof(numFrames));
-        }
-
-        return declared;
-    }
+        => VideoClipFrameCount.Resolve(architecture, numFrames, DefaultNumFrames);
 
     #endregion
 

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -38,6 +38,14 @@ namespace AiDotNet.Video.ActionRecognition;
 /// - Joint space-time attention mechanism
 /// </para>
 /// <para>
+/// <b>Pretraining:</b> call <see cref="PretrainMAE"/> repeatedly on unlabeled clips; each call is one
+/// optimizer step on the masked-patch reconstruction loss (per-patch normalised pixel targets by default,
+/// see <see cref="VideoMAEOptions.NormalizeTarget"/>). Then fine-tune the classifier with <c>Train</c>.
+/// The encoder here is a convolutional stand-in for the paper's ViT: masked patches are kept at zero
+/// through every encoder block (the sparse-convolution form of dropping them), and the decoder is a small
+/// convolutional stack with a per-patch pixel head.
+/// </para>
+/// <para>
 /// <b>Reference:</b> Tong et al., "VideoMAE: Masked Autoencoders are Data-Efficient Learners for Self-Supervised Video Pre-Training"
 /// NeurIPS 2022.
 /// </para>
@@ -323,10 +331,27 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     }
 
     /// <summary>
-    /// Performs masked autoencoder pretraining on a video.
+    /// Performs one masked-autoencoder pretraining step on a video clip: masks it, reconstructs the
+    /// masked tubelet patches, and updates the encoder, decoder and reconstruction head to reduce the
+    /// reconstruction error.
     /// </summary>
     /// <param name="video">Video tensor [T, C, H, W] or [B, T, C, H, W].</param>
-    /// <returns>Reconstruction loss.</returns>
+    /// <returns>This step's reconstruction loss, measured before the weight update.</returns>
+    /// <remarks>
+    /// <para>
+    /// Call this repeatedly over unlabeled clips to pretrain (Tong et al. 2022, Sec. 3), then fine-tune
+    /// with <see cref="Train(Tensor{T}, Tensor{T})"/>. Each call samples a new tube mask at the configured mask ratio, runs the
+    /// masked encoder and the reconstruction decoder on the autodiff tape, takes the mean squared error
+    /// over the masked patches only (against per-patch normalised pixels by default - see
+    /// <see cref="VideoMAEOptions.NormalizeTarget"/>), and applies one optimizer step through the
+    /// library's standard caller-owned-tape training path. The optimizer is the one passed to the
+    /// constructor, or the model's default Adam.
+    /// </para>
+    /// <para>
+    /// It used to compute the loss and return it without back-propagating or updating anything, so
+    /// "pretraining" never changed a weight.
+    /// </para>
+    /// </remarks>
     public T PretrainMAE(Tensor<T> video)
     {
         if (!_useNativeMode)
@@ -334,26 +359,42 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             throw new InvalidOperationException("Pretraining is not supported in ONNX mode.");
         }
 
-        bool hasBatch = video.Rank == 5;
-        if (!hasBatch)
+        if (video is null)
         {
-            video = AddBatchDimension5D(video);
+            throw new ArgumentNullException(nameof(video));
         }
+
+        if (video.Rank != 4 && video.Rank != 5)
+        {
+            throw new ArgumentException("PretrainMAE expects a clip [T, C, H, W] or a batch of clips [B, T, C, H, W].", nameof(video));
+        }
+
+        // The clip is data, not a parameter, so promoting it with a copy costs no gradient path.
+        var clip = video.Rank == 5 ? video : AddBatchDimension5D(video);
 
         // Create the tube mask on this clip's own patch grid (one spatial mask per clip, shared by
         // every tubelet).
-        var mask = CreateTubeMask(video.Shape[0], video.Shape[3] / _patchSize, video.Shape[4] / _patchSize);
+        var mask = CreateTubeMask(clip.Shape[0], clip.Shape[3] / _patchSize, clip.Shape[4] / _patchSize);
 
-        // Encode visible patches
-        var visibleFeatures = EncodeVisiblePatches(video, mask);
-
-        // Decode to reconstruct full video
-        var reconstruction = DecodeForReconstruction(visibleFeatures);
-
-        // Compute reconstruction loss on masked patches
-        T loss = ComputeReconstructionLoss(reconstruction, video, mask);
-
-        return loss;
+        bool wasTraining = IsTrainingMode;
+        SetTrainingMode(true);
+        try
+        {
+            // The forward and the loss are recorded on this tape; BackwardAndStepOnPrecomputedLoss runs
+            // backward over it and applies the optimizer step, the same entry point the library's other
+            // custom-objective models (NeRF, TVAE, TabDDPM, the GANs) train through.
+            using var tape = new AiDotNet.Tensors.Engines.Autodiff.GradientTape<T>();
+            var reconstruction = DecodeForReconstruction(EncodeVisiblePatches(clip, mask));
+            var loss = ReconstructionObjective(reconstruction, clip, mask);
+            return BackwardAndStepOnPrecomputedLoss(tape, loss, _optimizer);
+        }
+        finally
+        {
+            if (!wasTraining)
+            {
+                SetTrainingMode(false);
+            }
+        }
     }
 
     /// <summary>
@@ -700,38 +741,58 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         return mask;
     }
 
-    private Tensor<T> EncodeVisiblePatches(Tensor<T> video, bool[,,] mask)
+    /// <summary>
+    /// Runs the pretraining encoder over only the VISIBLE tubelet patches of a clip.
+    /// </summary>
+    /// <param name="video">The clip [B, T, C, H, W].</param>
+    /// <param name="mask">Tube mask [B, patchesH, patchesW] (true = masked), shared by all tubelets.</param>
+    /// <returns>Encoder features [B * numTubelets, numFeatures, patchesH, patchesW], exactly zero at
+    /// every masked patch.</returns>
+    /// <remarks>
+    /// <para>
+    /// The paper's encoder drops masked tokens and runs its transformer on the visible ones only
+    /// (Tong et al. 2022, Sec. 3.3), so masked patches contribute nothing to it. This model's encoder is
+    /// a stack of 3x3 convolutions over the patch grid, which cannot drop grid positions: a convolution
+    /// needs the whole grid. It is made sparse the way masked-image-modelling work on convolutional
+    /// encoders does it (SparK, Tian et al. 2023; ConvNeXt V2's FCMAE, Woo et al. 2023): the binary
+    /// visibility mask is applied to the patch embedding and again after EVERY encoder block. A masked
+    /// position then holds exactly zero at every block input, so it adds nothing to its visible
+    /// neighbours (the same as zero padding), and it never accumulates a value of its own.
+    /// </para>
+    /// <para>
+    /// Previously the mask was applied once, to the embedding, by writing zeros into it in place. Two
+    /// defects followed. The 3x3 blocks immediately refilled every masked position from its visible
+    /// neighbours plus the block's bias, so from the second block on the encoder was processing masked
+    /// positions as ordinary tokens. And the in-place write was invisible to the autodiff tape, so the
+    /// backward pass still routed gradient through the embedding's masked outputs into the
+    /// patch-embedding weights - weighted by the masked patches' own pixels, i.e. the very content the
+    /// model is meant to predict without seeing. Both masks here are recorded multiplies, so the
+    /// masked positions receive neither a value nor a gradient.
+    /// </para>
+    /// <para>
+    /// The decoder receives these features with zeros at the masked positions; the paper's learned mask
+    /// token is not added (it would be a new parameter), so a masked position enters the decoder as a
+    /// fixed zero "mask token" and the decoder's convolutions fill it from the visible context.
+    /// </para>
+    /// </remarks>
+    internal Tensor<T> EncodeVisiblePatches(Tensor<T> video, bool[,,] mask)
     {
         var patchEmbedded = PatchEmbed(video);
 
-        // Apply mask (zero out masked patches)
-        // Note: patchEmbedded has shape [B * numTubelets, C, H, W] while mask has shape [B, patchesH, patchesW]
+        // patchEmbedded is [B * numTubelets, F, patchesH, patchesW]; mask is [B, patchesH, patchesW].
         int batchSize = video.Shape[0];
         int numTubelets = video.Shape[1] / _tubeletSize;
-        int channels = patchEmbedded.Shape[1];
-        int height = patchEmbedded.Shape[2];
-        int width = patchEmbedded.Shape[3];
-
-        for (int b = 0; b < batchSize; b++)
+        if (mask.GetLength(0) != batchSize
+            || mask.GetLength(1) != patchEmbedded.Shape[2]
+            || mask.GetLength(2) != patchEmbedded.Shape[3])
         {
-            for (int t = 0; t < numTubelets; t++)
-            {
-                int tubeletIdx = b * numTubelets + t;
-                for (int h = 0; h < height; h++)
-                {
-                    for (int w = 0; w < width; w++)
-                    {
-                        if (mask[b, h % mask.GetLength(1), w % mask.GetLength(2)])
-                        {
-                            for (int c = 0; c < channels; c++)
-                            {
-                                patchEmbedded[tubeletIdx, c, h, w] = NumOps.Zero;
-                            }
-                        }
-                    }
-                }
-            }
+            throw new ArgumentException(
+                $"The mask [{mask.GetLength(0)}, {mask.GetLength(1)}, {mask.GetLength(2)}] does not match the clip's " +
+                $"batch size {batchSize} and patch grid [{patchEmbedded.Shape[2]}, {patchEmbedded.Shape[3]}].",
+                nameof(mask));
         }
+
+        var visible = BuildPatchMask(mask, numTubelets, patchEmbedded.Shape[1], keepMasked: false);
 
         // Apply encoder blocks. Each Layers[i] is a shape-preserving
         // Conv(numFeatures, 3, 1, 1) whose built-in ReLU records on the autodiff
@@ -744,14 +805,59 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         // magnitude grow monotonically across the 12-block stack, blowing up the
         // classification logits and saturating the softmax so the output stops
         // responding to input changes.
-        var features = patchEmbedded;
+        var features = Engine.TensorMultiply(patchEmbedded, visible);
         int encoderLayerCount = Math.Min(VideoMAELayerLayout.EncoderEndIndex, Layers.Count);
         for (int i = VideoMAELayerLayout.FirstEncoderBlockIndex; i < encoderLayerCount; i++)
         {
-            features = Layers[i].Forward(features);
+            features = Engine.TensorMultiply(Layers[i].Forward(features), visible);
         }
 
         return features;
+    }
+
+    /// <summary>
+    /// Expands a tube mask to a 0/1 tensor over a per-tubelet feature or prediction map.
+    /// </summary>
+    /// <param name="mask">Tube mask [B, patchesH, patchesW] (true = masked).</param>
+    /// <param name="numTubelets">Tubelets per clip.</param>
+    /// <param name="channels">Channel extent of the map the result multiplies.</param>
+    /// <param name="keepMasked">True for 1 at masked patches (the loss), false for 1 at visible patches
+    /// (the encoder).</param>
+    /// <returns>A [B * numTubelets, channels, patchesH, patchesW] constant.</returns>
+    private Tensor<T> BuildPatchMask(bool[,,] mask, int numTubelets, int channels, bool keepMasked)
+    {
+        int batchSize = mask.GetLength(0);
+        int patchesH = mask.GetLength(1);
+        int patchesW = mask.GetLength(2);
+        int plane = patchesH * patchesW;
+
+        var result = new Tensor<T>([batchSize * numTubelets, channels, patchesH, patchesW]);
+        var span = result.Data.Span;
+        for (int b = 0; b < batchSize; b++)
+        {
+            for (int t = 0; t < numTubelets; t++)
+            {
+                int rowOffset = (b * numTubelets + t) * channels * plane;
+                for (int ph = 0; ph < patchesH; ph++)
+                {
+                    for (int pw = 0; pw < patchesW; pw++)
+                    {
+                        if (mask[b, ph, pw] != keepMasked)
+                        {
+                            continue;
+                        }
+
+                        int position = ph * patchesW + pw;
+                        for (int c = 0; c < channels; c++)
+                        {
+                            span[rowOffset + c * plane + position] = NumOps.One;
+                        }
+                    }
+                }
+            }
+        }
+
+        return result;
     }
 
     /// <summary>
@@ -760,10 +866,20 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// <param name="features">Encoder features [B * numTubelets, numFeatures, patchesH, patchesW].</param>
     /// <returns>Per-patch pixel predictions [B * numTubelets, channels * tubeletSize * P * P, patchesH, patchesW].</returns>
     /// <remarks>
+    /// <para>
     /// The decoder slice is addressed through <see cref="VideoMAELayerLayout"/>. It used to start at a
     /// hard-coded index 15 — the classifier's <c>DenseLayer</c> — so pretraining pushed the encoder maps
     /// through the class head, ran three of the four decoder blocks, used the fourth as the "head", and
     /// never reached the real reconstruction head (whose output is the only one sized to a tubelet patch).
+    /// </para>
+    /// <para>
+    /// Each decoder block is a Conv(numFeatures, 3, 1, 1) with its own ReLU, and nothing else is applied
+    /// between blocks. A second, <c>Tensor.Transform</c>-based GELU used to be stacked on every block's
+    /// output. Transform records no autodiff node, so it severed the tape after every block: a
+    /// reconstruction loss could reach the head and nothing before it - no decoder block, no encoder
+    /// block, no patch embedding. It was also numerically redundant (GELU of a ReLU output is a mild
+    /// squash of a non-negative value). The encoder had the identical defect and was fixed the same way.
+    /// </para>
     /// </remarks>
     internal Tensor<T> DecodeForReconstruction(Tensor<T> features)
     {
@@ -774,7 +890,6 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             for (int i = VideoMAELayerLayout.FirstDecoderBlockIndex; i < VideoMAELayerLayout.ReconstructionHeadIndex; i++)
             {
                 decoded = Layers[i].Forward(decoded);
-                decoded = ApplyGELU(decoded);
             }
 
             decoded = Layers[VideoMAELayerLayout.ReconstructionHeadIndex].Forward(decoded);
@@ -784,7 +899,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     }
 
     /// <summary>
-    /// Mean squared error between the predicted and the true pixels of the MASKED tubelet patches.
+    /// Mean squared error between the predicted and the target pixels of the MASKED tubelet patches.
     /// </summary>
     /// <param name="reconstructed">Reconstruction-head output
     /// [B * numTubelets, channels * tubeletSize * P * P, patchesH, patchesW].</param>
@@ -806,11 +921,28 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     /// as a clip had two or more tubelets (IndexOutOfRange from <see cref="PretrainMAE"/>).
     /// </para>
     /// <para>
-    /// The target is raw pixels. The reference implementation's optional per-patch target normalisation
-    /// (<c>normlize_target</c>) is not applied.
+    /// The target is the per-patch normalised pixels by default and the raw pixels when
+    /// <see cref="VideoMAEOptions.NormalizeTarget"/> is off; see <see cref="BuildReconstructionTarget"/>.
+    /// This is the value of the same objective <see cref="PretrainMAE"/> differentiates.
     /// </para>
     /// </remarks>
     internal T ComputeReconstructionLoss(Tensor<T> reconstructed, Tensor<T> original, bool[,,] mask)
+    {
+        using var _ = new AiDotNet.Tensors.Engines.Autodiff.NoGradScope<T>();
+        var loss = ReconstructionObjective(reconstructed, original, mask);
+        return loss.Length > 0 ? loss.Data.Span[0] : NumOps.Zero;
+    }
+
+    /// <summary>
+    /// The masked-patch reconstruction objective as a scalar tensor on the autodiff tape.
+    /// </summary>
+    /// <remarks>
+    /// Expressed as engine operations (subtract, square, multiply by a 0/1 masked-patch tensor, sum, scale)
+    /// so that, recorded on a tape, it back-propagates into the reconstruction head, the decoder, the
+    /// encoder and the patch embedding. The squared error of a VISIBLE patch is multiplied by zero, so it
+    /// contributes neither loss nor gradient.
+    /// </remarks>
+    private Tensor<T> ReconstructionObjective(Tensor<T> reconstructed, Tensor<T> original, bool[,,] mask)
     {
         if (original.Rank != 5)
         {
@@ -845,38 +977,134 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             throw new ArgumentException("The mask does not match the clip's batch size and patch grid.", nameof(mask));
         }
 
-        T loss = NumOps.Zero;
-        int count = 0;
-
+        int maskedPatches = 0;
         for (int b = 0; b < batchSize; b++)
         {
             for (int ph = 0; ph < patchesH; ph++)
             {
                 for (int pw = 0; pw < patchesW; pw++)
                 {
-                    if (!mask[b, ph, pw])
+                    if (mask[b, ph, pw])
                     {
-                        continue;
+                        maskedPatches++;
                     }
+                }
+            }
+        }
 
-                    for (int t = 0; t < numTubelets; t++)
+        // Every masked patch contributes patchDim values in each of the clip's tubelets.
+        long count = (long)maskedPatches * numTubelets * patchDim;
+
+        var target = BuildReconstructionTarget(original, patchesH, patchesW);
+        var maskedOnly = BuildPatchMask(mask, numTubelets, patchDim, keepMasked: true);
+
+        var diff = Engine.TensorSubtract(reconstructed, target);
+        var squaredMasked = Engine.TensorMultiply(Engine.TensorMultiply(diff, diff), maskedOnly);
+        var allAxes = Enumerable.Range(0, squaredMasked.Rank).ToArray();
+        var total = Engine.ReduceSum(squaredMasked, allAxes, keepDims: false);
+
+        // With nothing masked the objective is an honest zero (and so is every gradient).
+        return Engine.TensorMultiplyScalar(total, NumOps.FromDouble(1.0 / Math.Max(1L, count)));
+    }
+
+    /// <summary>
+    /// The per-patch reconstruction target for a clip, laid out like the reconstruction head's output.
+    /// </summary>
+    /// <param name="original">The clip [B, T, C, H, W].</param>
+    /// <param name="patchesH">Patch rows.</param>
+    /// <param name="patchesW">Patch columns.</param>
+    /// <returns>[B * numTubelets, C * tubeletSize * P * P, patchesH, patchesW]: channel
+    /// <c>((ts * C + c) * P + y) * P + x</c> at patch <c>(ph, pw)</c> of tubelet <c>t</c> holds pixel
+    /// <c>original[b, t * tubeletSize + ts, c, ph * P + y, pw * P + x]</c>, normalised or raw.</returns>
+    /// <remarks>
+    /// <para>
+    /// With <see cref="VideoMAEOptions.NormalizeTarget"/> on (the default, as in the paper), every channel
+    /// of every tubelet patch is normalised over its own <c>tubeletSize x P x P</c> pixels:
+    /// <c>(x - mean) / (std + 1e-6)</c> with the unbiased standard deviation. This is the reference
+    /// implementation's <c>normlize_target=True</c> (VideoMAE <c>engine_for_pretraining.py</c>: a
+    /// <c>b (t h w) (p0 p1 p2) c</c> view normalised over the <c>p0 p1 p2</c> axis), which the paper
+    /// inherits from MAE (He et al. 2022, Sec. 4), where it improves representation quality. With it off,
+    /// the target is the raw pixels.
+    /// </para>
+    /// </remarks>
+    private Tensor<T> BuildReconstructionTarget(Tensor<T> original, int patchesH, int patchesW)
+    {
+        if (original.Rank != 5)
+        {
+            throw new ArgumentException("The original clip must be [B, T, C, H, W].", nameof(original));
+        }
+
+        int batchSize = original.Shape[0];
+        int numTubelets = original.Shape[1] / _tubeletSize;
+        int channels = original.Shape[2];
+        int patch = _patchSize;
+        int patchDim = channels * _tubeletSize * patch * patch;
+        int pixelsPerPatchChannel = _tubeletSize * patch * patch;
+        bool normalize = _options.NormalizeTarget;
+
+        var target = new Tensor<T>([batchSize * numTubelets, patchDim, patchesH, patchesW]);
+        var destination = target.Data.Span;
+        int plane = patchesH * patchesW;
+        var values = new double[pixelsPerPatchChannel];
+
+        for (int b = 0; b < batchSize; b++)
+        {
+            for (int t = 0; t < numTubelets; t++)
+            {
+                int row = b * numTubelets + t;
+                for (int ph = 0; ph < patchesH; ph++)
+                {
+                    for (int pw = 0; pw < patchesW; pw++)
                     {
-                        int row = b * numTubelets + t;
-                        for (int ts = 0; ts < _tubeletSize; ts++)
+                        for (int c = 0; c < channels; c++)
                         {
-                            int frame = t * _tubeletSize + ts;
-                            for (int c = 0; c < channels; c++)
+                            int k = 0;
+                            for (int ts = 0; ts < _tubeletSize; ts++)
+                            {
+                                int frame = t * _tubeletSize + ts;
+                                for (int y = 0; y < patch; y++)
+                                {
+                                    for (int x = 0; x < patch; x++)
+                                    {
+                                        values[k++] = NumOps.ToDouble(
+                                            original[b, frame, c, ph * patch + y, pw * patch + x]);
+                                    }
+                                }
+                            }
+
+                            double mean = 0.0;
+                            double scale = 1.0;
+                            if (normalize)
+                            {
+                                for (int i = 0; i < values.Length; i++)
+                                {
+                                    mean += values[i];
+                                }
+                                mean /= values.Length;
+
+                                double sumSquares = 0.0;
+                                for (int i = 0; i < values.Length; i++)
+                                {
+                                    double d = values[i] - mean;
+                                    sumSquares += d * d;
+                                }
+
+                                double unbiasedVariance = values.Length > 1 ? sumSquares / (values.Length - 1) : 0.0;
+                                scale = 1.0 / (Math.Sqrt(unbiasedVariance) + 1e-6);
+                            }
+
+                            k = 0;
+                            for (int ts = 0; ts < _tubeletSize; ts++)
                             {
                                 for (int y = 0; y < patch; y++)
                                 {
                                     for (int x = 0; x < patch; x++)
                                     {
                                         int channel = (((ts * channels) + c) * patch + y) * patch + x;
-                                        T diff = NumOps.Subtract(
-                                            reconstructed[row, channel, ph, pw],
-                                            original[b, frame, c, ph * patch + y, pw * patch + x]);
-                                        loss = NumOps.Add(loss, NumOps.Multiply(diff, diff));
-                                        count++;
+                                        double value = normalize ? (values[k] - mean) * scale : values[k];
+                                        destination[(row * patchDim + channel) * plane + ph * patchesW + pw] =
+                                            NumOps.FromDouble(value);
+                                        k++;
                                     }
                                 }
                             }
@@ -886,7 +1114,7 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
             }
         }
 
-        return count > 0 ? NumOps.Divide(loss, NumOps.FromDouble(count)) : NumOps.Zero;
+        return target;
     }
 
     private Tensor<T> GlobalAveragePool(Tensor<T> input)
@@ -905,17 +1133,6 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         var reshaped = Engine.Reshape(input, new[] { batchSize, channels, height * width });
         var meanBC = Engine.ReduceMean(reshaped, new[] { 2 }, keepDims: false);  // [B, C]
         return Engine.Reshape(meanBC, new[] { batchSize, channels, 1, 1 });
-    }
-
-    private Tensor<T> ApplyGELU(Tensor<T> input)
-    {
-        return input.Transform((v, _) =>
-        {
-            double x = Convert.ToDouble(v);
-            double c = Math.Sqrt(2.0 / Math.PI);
-            double gelu = 0.5 * x * (1.0 + Math.Tanh(c * (x + 0.044715 * x * x * x)));
-            return NumOps.FromDouble(gelu);
-        });
     }
 
     private Tensor<T> ApplySoftmax(Tensor<T> input)

--- a/src/Video/Enhancement/BasicVSRPlusPlus.cs
+++ b/src/Video/Enhancement/BasicVSRPlusPlus.cs
@@ -446,8 +446,10 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
     /// <summary>
     /// Enhances a sequence of video frames using temporal super-resolution.
     /// </summary>
-    /// <param name="frames">Input frames tensor with shape [numFrames, channels, height, width].</param>
-    /// <returns>Enhanced frames tensor with shape [numFrames, channels, height*scale, width*scale].</returns>
+    /// <param name="frames">Input frames tensor with shape [numFrames, channels, height, width], or a single
+    /// frame [channels, height, width].</param>
+    /// <returns>Enhanced frames tensor with shape [numFrames, channels, height*scale, width*scale], or
+    /// [channels, height*scale, width*scale] for a single frame.</returns>
     /// <remarks>
     /// <para>
     /// <b>For Beginners:</b> Pass your low-resolution video frames as a 4D tensor:
@@ -458,6 +460,13 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
     /// SaveVideoFrames(hrFrames, "output_4x.mp4");
     /// </code>
     /// </para>
+    /// <para>
+    /// A single frame <c>[C, H, W]</c> - the shape this model's own default architecture declares - is
+    /// the degenerate one-frame clip of the super-resolution family contract: it is upscaled as a clip of
+    /// length one (no neighbours, so no propagation) and returned without the frame axis. It used to be
+    /// read as a clip of <c>C</c> two-dimensional "frames", so the model could not run on its own declared
+    /// input shape.
+    /// </para>
     /// </remarks>
     public Tensor<T> EnhanceVideo(Tensor<T> frames)
     {
@@ -466,6 +475,14 @@ public partial class BasicVSRPlusPlus<T> : VideoSuperResolutionBase<T>
 
         if (_useNativeMode)
         {
+            if (frames.Rank == 3)
+            {
+                // Recorded reshapes, so training through a single frame keeps its gradient path.
+                var clip = Engine.Reshape(frames, [1, frames.Shape[0], frames.Shape[1], frames.Shape[2]]);
+                var enhanced = EnhanceVideoNative(clip);
+                return Engine.Reshape(enhanced, [enhanced.Shape[1], enhanced.Shape[2], enhanced.Shape[3]]);
+            }
+
             return EnhanceVideoNative(frames);
         }
         else

--- a/src/Video/Generation/OpenSora.cs
+++ b/src/Video/Generation/OpenSora.cs
@@ -345,10 +345,25 @@ public partial class OpenSora<T> : NeuralNetworkBase<T>
     /// <summary>
     /// Performs a single denoising prediction step on the input latents.
     /// </summary>
-    /// <param name="input">Input latent tensor [B, C, H, W].</param>
-    /// <returns>Predicted denoised output.</returns>
+    /// <param name="input">Input latent tensor [B, C, H, W], or a single latent [C, H, W].</param>
+    /// <returns>Predicted denoised output, in the input's shape.</returns>
+    /// <remarks>
+    /// A single latent <c>[C, H, W]</c> - the shape this model's default architecture declares - is
+    /// denoised as a batch of one and returned without the batch axis, the same promotion the model
+    /// already applies to single images elsewhere (see <c>AddBatchDimension</c>). The denoiser indexes
+    /// axis 3 of its features, so a rank-3 latent used to throw IndexOutOfRange.
+    /// </remarks>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (input.Rank == 3)
+        {
+            var denoised = PredictCore(AddBatchDimension(input));
+            return denoised.Reshape([denoised.Shape[1], denoised.Shape[2], denoised.Shape[3]]);
+        }
+
         // Create default time embedding at t=0.5 (mid-point)
         var timeEmbed = CreateTimeEmbedding(0.5);
 

--- a/src/Video/Inpainting/ProPainter.cs
+++ b/src/Video/Inpainting/ProPainter.cs
@@ -261,6 +261,19 @@ public partial class ProPainter<T> : VideoInpaintingBase<T>
         // inference through RunImagePath makes Predict reflect the learned weights, exactly as
         // ForwardForTraining does, so the two agree. The flow/warp/blend branch of InpaintFrame is
         // a non-differentiable, dead pathway and is intentionally omitted here too.
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        // A single frame [C, H, W] - the shape this model's default architecture declares - is the
+        // one-frame clip: frames are reconstructed independently (the image path treats the frame axis
+        // as its batch), so it runs as [1, C, H, W] and comes back without that axis. The image path
+        // reads axis 3, so a rank-3 frame used to throw IndexOutOfRange.
+        if (input.Rank == 3)
+        {
+            var frame = RunReconstruction(Engine.Reshape(input, [1, input.Shape[0], input.Shape[1], input.Shape[2]]));
+            return Engine.Reshape(frame, [frame.Shape[1], frame.Shape[2], frame.Shape[3]]);
+        }
+
         return RunReconstruction(input);
     }
 

--- a/src/Video/Motion/RAFT.cs
+++ b/src/Video/Motion/RAFT.cs
@@ -264,8 +264,31 @@ public partial class RAFT<T> : OpticalFlowBase<T>
     }
 
     /// <inheritdoc/>
+    /// <remarks>
+    /// Takes a stacked frame pair <c>[batch, 2*channels, height, width]</c> or, unbatched,
+    /// <c>[2*channels, height, width]</c> - the two forms the inherited <see cref="OpticalFlowBase{T}"/>
+    /// input layout declares. The unbatched pair is promoted to a batch of one and the unit batch axis is
+    /// removed from the flow, so it returns <c>[2, height, width]</c>. It used to index <c>Shape[3]</c> of
+    /// whatever it was given, so an unbatched pair threw IndexOutOfRange.
+    /// </remarks>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (input.Rank == 3)
+        {
+            var flow = PredictCore(PromoteToBatchedTensor(input));
+            return flow.Rank == 4 && flow.Shape[0] == 1
+                ? Engine.Reshape(flow, [flow.Shape[1], flow.Shape[2], flow.Shape[3]])
+                : flow;
+        }
+
+        if (input.Rank != 4)
+            throw new ArgumentException(
+                "RAFT expects a stacked frame pair [2*channels, height, width] or [batch, 2*channels, height, width], "
+                + $"got rank {input.Rank}.", nameof(input));
+
         var frame1 = SliceChannels(input, 0, _channels);
         var frame2 = SliceChannels(input, _channels, _channels * 2);
         var flowIterations = ForwardIterative(frame1, frame2);

--- a/src/Video/OpticalFlowBase.cs
+++ b/src/Video/OpticalFlowBase.cs
@@ -40,12 +40,13 @@ namespace AiDotNet.Video;
 /// </para>
 /// </remarks>
 [TensorLayout(TensorAxis.Batch, TensorAxis.Channels, TensorAxis.Height, TensorAxis.Width,
-    Direction = TensorLayoutDirection.Input,
+    Direction = TensorLayoutDirection.Input, BatchOptional = true,
     Note = "A frame PAIR stacked on the channel axis, so this axis is 2*channels. PredictCore "
-         + "rejects an odd channel count for exactly that reason.")]
+         + "rejects an odd channel count for exactly that reason. An unbatched pair [2*C, H, W] is "
+         + "promoted to a batch of one.")]
 [TensorLayout(TensorAxis.Batch, TensorAxis.Channels, TensorAxis.Height, TensorAxis.Width,
-    Direction = TensorLayoutDirection.Output,
-    Note = "A flow field: two channels, dx and dy, at the input resolution.")]
+    Direction = TensorLayoutDirection.Output, BatchOptional = true,
+    Note = "A flow field: two channels, dx and dy, at the input resolution. Unbatched in, unbatched out.")]
 public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IShapeContract
 {
     /// <summary>
@@ -53,10 +54,11 @@ public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IS
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Read from <see cref="PredictCore"/> rather than probed. It requires rank 4
+    /// Read from <see cref="PredictCore"/> rather than probed. It takes rank 4
     /// <c>[batch, 2*channels, height, width]</c> - two frames stacked on the channel axis, which is
     /// why it rejects an odd channel count - and returns one flow field per sample at the input
-    /// resolution.
+    /// resolution. A rank-3 <c>[2*channels, height, width]</c> pair is the same contract without the
+    /// batch axis, and returns <c>[2, height, width]</c>.
     /// </para>
     /// <para>
     /// The channel axis is <c>Fixed(2)</c> and NOT derived from the input's, which is the whole point
@@ -71,6 +73,16 @@ public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IS
     /// </remarks>
     public virtual IReadOnlyList<OutputAxisContract>? OutputAxesFor(int inputRank)
     {
+        if (inputRank == 3)
+        {
+            return
+            [
+                new OutputAxisContract(TensorAxis.Channels, AxisRelation.Fixed(2)),
+                new OutputAxisContract(TensorAxis.Height, AxisRelation.Same(TensorAxis.Height)),
+                new OutputAxisContract(TensorAxis.Width, AxisRelation.Same(TensorAxis.Width)),
+            ];
+        }
+
         if (inputRank != 4) return null;
         return
         [
@@ -324,11 +336,50 @@ public abstract partial class OpticalFlowBase<T> : VideoNeuralNetworkBase<T>, IS
     }
 
     /// <inheritdoc />
+    /// <remarks>
+    /// <para>
+    /// Accepts a stacked frame pair either batched, <c>[batch, 2*channels, height, width]</c>, or as a
+    /// single unbatched sample, <c>[2*channels, height, width]</c>. The unbatched form is what most of the
+    /// family's architectures declare (<c>InputType.ThreeDimensional</c> with <c>InputDepth</c> equal to
+    /// the stacked pair's channel count, so <c>GetInputShape()</c> is <c>[2*channels, H, W]</c>). It is
+    /// promoted to a batch of one with the shared <see cref="NeuralNetworkBase{T}.PromoteToBatchedTensor"/>
+    /// helper and the unit batch axis is removed from the result - unbatched in, unbatched out, the same
+    /// rule the base <c>PredictCore</c> applies to every model that inherits it.
+    /// </para>
+    /// <para>
+    /// This used to reject every rank-3 input with "Input must be rank 4", so every pair-declaring model
+    /// that relies on this method failed <c>Predict</c> on a tensor of its own declared input shape.
+    /// </para>
+    /// </remarks>
     protected override Tensor<T> PredictCore(Tensor<T> input)
     {
+        if (input is null)
+            throw new ArgumentNullException(nameof(input));
+
+        if (input.Rank == 3)
+        {
+            var flow = PredictBatchedPair(PromoteToBatchedTensor(input));
+            if (flow.Rank != 4 || flow.Shape[0] != 1)
+                return flow;
+
+            // Engine.Reshape (not a raw copy) so the squeeze stays on the tape: PredictCore is
+            // deliberately differentiable with respect to the frames (see the narrow below).
+            return Engine.Reshape(flow, [flow.Shape[1], flow.Shape[2], flow.Shape[3]]);
+        }
+
+        return PredictBatchedPair(input);
+    }
+
+    /// <summary>
+    /// Estimates flow for a batched stacked pair <c>[batch, 2*channels, height, width]</c>.
+    /// </summary>
+    private Tensor<T> PredictBatchedPair(Tensor<T> input)
+    {
         // For optical flow, input should contain two frames stacked [batch, 2*channels, height, width]
-        if (input.Rank < 4)
-            throw new ArgumentException($"Input must be rank 4 [batch, 2*channels, height, width], got rank {input.Rank}.", nameof(input));
+        if (input.Rank != 4)
+            throw new ArgumentException(
+                "Input must be rank 3 [2*channels, height, width] or rank 4 [batch, 2*channels, height, width], "
+                + $"got rank {input.Rank}.", nameof(input));
         if (input.Shape[1] % 2 != 0)
             throw new ArgumentException($"Input channel dimension must be even (two frames stacked), got {input.Shape[1]}.", nameof(input));
         int batch = input.Shape[0];

--- a/src/Video/Options/VideoMAEOptions.cs
+++ b/src/Video/Options/VideoMAEOptions.cs
@@ -7,4 +7,25 @@ namespace AiDotNet.Video.Options;
 /// </summary>
 public class VideoMAEOptions : NeuralNetworkOptions
 {
+    /// <summary>
+    /// Gets or sets whether masked-autoencoder pretraining reconstructs per-patch NORMALISED pixels
+    /// rather than raw pixels. Default: <c>true</c>, the paper's setting.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When on, <c>PretrainMAE</c>'s target for each channel of each masked tubelet patch is that patch's
+    /// pixels standardised over its own <c>tubeletSize x 16 x 16</c> values, <c>(x - mean) / (std + 1e-6)</c>
+    /// with the unbiased standard deviation. This is the VideoMAE reference implementation's
+    /// <c>normlize_target=True</c> default (Tong et al. 2022), carried over from MAE (He et al. 2022,
+    /// Sec. 4), where predicting normalised patches improves the learned representation: the model
+    /// spends its capacity on local structure rather than on each patch's brightness and contrast.
+    /// </para>
+    /// <para>
+    /// When off, the target is the raw pixel values. Classification (<c>Predict</c>/<c>Train</c>) is not
+    /// affected either way.
+    /// </para>
+    /// <para><b>For Beginners:</b> Leave this on unless you need the reconstruction loss in raw pixel
+    /// units (for example, to compare against an older raw-pixel run).</para>
+    /// </remarks>
+    public bool NormalizeTarget { get; set; } = true;
 }

--- a/src/Video/Understanding/VideoCLIP.cs
+++ b/src/Video/Understanding/VideoCLIP.cs
@@ -179,15 +179,26 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
 
     #region Constructors
 
+    /// <summary>Default clip length (frames) when neither the caller nor the architecture declares one.</summary>
+    private const int DefaultNumFrames = 32;
+
     /// <summary>
-    /// Initializes a new instance with default architecture settings.
+    /// Initializes a new instance with default architecture settings (32-frame 224x224 RGB clips).
     /// </summary>
+    /// <remarks>
+    /// The declared input is the clip the model encodes, <c>[32, 3, 224, 224]</c>
+    /// (<see cref="Enums.InputType.FourDimensional"/> with <c>inputFrames</c> equal to the default
+    /// <c>numFrames</c>), matching the model's <c>[Frames, Channels, Height, Width]</c> input layout. It used
+    /// to be <see cref="Enums.InputType.ThreeDimensional"/>, i.e. a single <c>[3, 224, 224]</c> frame, which
+    /// <see cref="EncodeVideo"/> cannot take: a tensor of the model's own declared input shape failed Predict.
+    /// </remarks>
     public VideoCLIP()
         : this(new NeuralNetworkArchitecture<T>(
-            inputType: Enums.InputType.ThreeDimensional,
+            inputType: Enums.InputType.FourDimensional,
             taskType: Enums.NeuralNetworkTaskType.MultiClassClassification,
             inputHeight: 224, inputWidth: 224, inputDepth: 3,
-            outputSize: 400))
+            outputSize: 400,
+            inputFrames: DefaultNumFrames))
     {
     }
 
@@ -195,7 +206,9 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
     /// Initializes a new instance of the VideoCLIP class.
     /// </summary>
     /// <param name="architecture">The neural network architecture configuration.</param>
-    /// <param name="numFrames">Number of video frames to process.</param>
+    /// <param name="numFrames">Number of video frames per clip (default: 32). When the architecture declares a
+    /// frame count (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) that count is used, as for
+    /// VideoMAE and TimeSformer; passing a different non-default value throws.</param>
     /// <param name="embeddingDim">Dimension of the shared embedding space.</param>
     /// <param name="textMaxLength">Maximum text sequence length.</param>
     /// <param name="vocabSize">Vocabulary size for text encoding.</param>
@@ -217,7 +230,7 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
     /// </remarks>
     public VideoCLIP(
         NeuralNetworkArchitecture<T> architecture,
-        int numFrames = 32,
+        int numFrames = DefaultNumFrames,
         int embeddingDim = 512,
         int textMaxLength = 77,
         int vocabSize = 49408,
@@ -235,7 +248,7 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
         _height = architecture.InputHeight > 0 ? architecture.InputHeight : 224;
         _width = architecture.InputWidth > 0 ? architecture.InputWidth : 224;
         _channels = architecture.InputDepth > 0 ? architecture.InputDepth : 3;
-        _numFrames = numFrames;
+        _numFrames = VideoClipFrameCount.Resolve(architecture, numFrames, DefaultNumFrames);
         _embeddingDim = embeddingDim;
         _textMaxLength = textMaxLength;
         _vocabSize = vocabSize;
@@ -1117,6 +1130,32 @@ public partial class VideoCLIP<T> : NeuralNetworkBase<T>
     #endregion
 
     #region Abstract Implementation
+
+    /// <summary>
+    /// The shape the lazy layers are resolved from ahead of the first forward: ONE frame,
+    /// <c>[1, C, H, W]</c>.
+    /// </summary>
+    /// <remarks>
+    /// The layer stack runs per frame (the spatial encoder consumes frames, not clips), so the
+    /// architecture-driven lazy-shape walk must start from a frame. It used to get exactly that by
+    /// accident: the default architecture declared a single <c>[3, 224, 224]</c> frame. Now that it declares
+    /// the clip Predict takes, <c>[Frames, C, H, W]</c>, the base walk would start from a rank-5 tensor the
+    /// first convolution rejects, leave the stack unresolved until the first forward, and under-report
+    /// <c>ParameterCount</c> until then (38.0M instead of 211.1M for the default model) - the count that
+    /// memory decisions such as weight streaming are gated on.
+    /// </remarks>
+    protected override int[]? TryGetArchitectureInputShape()
+    {
+        if (Architecture.IsLayerOnly)
+        {
+            return base.TryGetArchitectureInputShape();
+        }
+
+        int channels = Architecture.InputDepth > 0 ? Architecture.InputDepth : 3;
+        int height = Architecture.InputHeight > 0 ? Architecture.InputHeight : 224;
+        int width = Architecture.InputWidth > 0 ? Architecture.InputWidth : 224;
+        return [1, channels, height, width];
+    }
 
     /// <inheritdoc/>
     protected override void InitializeLayers()

--- a/src/Video/VideoClipFrameCount.cs
+++ b/src/Video/VideoClipFrameCount.cs
@@ -1,0 +1,53 @@
+using AiDotNet.NeuralNetworks;
+
+namespace AiDotNet.Video;
+
+/// <summary>
+/// The one rule for reconciling a clip model's <c>numFrames</c> constructor argument with the frame count
+/// its architecture declares.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The architecture is the model's declared input contract: for a temporal-video architecture
+/// <c>GetInputShape()</c> is <c>[InputFrames, C, H, W]</c>, and the auto-batching rank check, generated
+/// fixtures and serving all size their inputs from it. So a frame count the architecture declares
+/// (<see cref="NeuralNetworkArchitecture{T}.InputFrames"/> &gt; 0) wins - the rule BSVD already applies. An
+/// explicit <c>numFrames</c> that disagrees with it is rejected rather than silently overridden, since the
+/// two would describe different clips.
+/// </para>
+/// <para>
+/// Limitation: a parameter's default value cannot be told apart from the same value passed explicitly, so
+/// passing exactly the default defers to the architecture instead of throwing.
+/// </para>
+/// </remarks>
+internal static class VideoClipFrameCount
+{
+    /// <summary>Resolves the clip length a model should be built for.</summary>
+    /// <param name="architecture">The model's architecture.</param>
+    /// <param name="numFrames">The <c>numFrames</c> constructor argument.</param>
+    /// <param name="defaultNumFrames">That argument's default value.</param>
+    /// <returns>The architecture's declared frame count when it declares one; otherwise <paramref name="numFrames"/>.</returns>
+    /// <exception cref="ArgumentException">An explicit, non-default <paramref name="numFrames"/> conflicts
+    /// with the architecture's declared frame count.</exception>
+    internal static int Resolve<T>(NeuralNetworkArchitecture<T> architecture, int numFrames, int defaultNumFrames)
+    {
+        if (architecture is null)
+            throw new ArgumentNullException(nameof(architecture));
+
+        int declared = architecture.InputFrames;
+        if (declared <= 0)
+        {
+            return numFrames;
+        }
+
+        if (numFrames != declared && numFrames != defaultNumFrames)
+        {
+            throw new ArgumentException(
+                $"numFrames ({numFrames}) conflicts with the architecture's declared InputFrames ({declared}). " +
+                "Pass the same value, or omit numFrames to use the architecture's frame count.",
+                nameof(numFrames));
+        }
+
+        return declared;
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/TimeSformerFrameCountTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/TimeSformerFrameCountTests.cs
@@ -1,0 +1,154 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.NeuralNetworks.Layers;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.ActionRecognition;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.ActionRecognition;
+
+/// <summary>
+/// TimeSformer must build for the clip length its architecture declares, and follow the library's
+/// unbatched-in / unbatched-out and per-sample-softmax conventions.
+/// </summary>
+/// <remarks>
+/// The frame count sizes the positional table (<c>frames * patches + 1</c> tokens) and is the group size the
+/// divided space-time blocks fall back to when run without an explicit frame count. The constructor used to
+/// take it from <c>numFrames</c> (default 8) and ignore <c>Architecture.InputFrames</c>, so a 16-frame
+/// architecture built an 8-frame model: it reported 8, grouped by 8, and could not run its own declared
+/// clip. The rule is VideoMAE's: the architecture wins, a conflicting explicit value throws.
+/// </remarks>
+public class TimeSformerFrameCountTests
+{
+    private const int Size = 32;
+    private const int Patch = 16;
+    private const int Classes = 5;
+
+    private static NeuralNetworkArchitecture<double> ClipArchitecture(int frames) => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: frames, inputDepth: 3, inputHeight: Size, inputWidth: Size,
+        outputSize: Classes);
+
+    private static TimeSformer<double> Small(NeuralNetworkArchitecture<double> architecture, int? numFrames = null)
+        => numFrames is int frames
+            ? new TimeSformer<double>(architecture, numClasses: Classes, embedDim: 16, numHeads: 2, numLayers: 1,
+                numFrames: frames, patchSize: Patch)
+            : new TimeSformer<double>(architecture, numClasses: Classes, embedDim: 16, numHeads: 2, numLayers: 1,
+                patchSize: Patch);
+
+    private static Tensor<double> Random(int[] shape, int seed)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<double>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return t;
+    }
+
+    [Fact]
+    public void Constructor_UsesTheFrameCountDeclaredByTheArchitecture()
+    {
+        var model = Small(ClipArchitecture(frames: 16));
+
+        Assert.Equal(16, model.NumFrames);
+        Assert.Equal(16, model.GetModelMetadata().AdditionalInfo["NumFrames"]);
+
+        // Every divided space-time block is built for the same clip length.
+        var blocks = model.Layers.OfType<TimeSformerBlockLayer<double>>().ToList();
+        Assert.NotEmpty(blocks);
+        Assert.All(blocks, block => Assert.Equal("16", block.GetMetadata()["NumFrames"]));
+    }
+
+    [Fact]
+    public void Predict_OnTheDeclaredSixteenFrameClip_Succeeds()
+    {
+        var model = Small(ClipArchitecture(frames: 16));
+
+        // [16, 3, 32, 32] -> 16 frames x 4 patches + CLS = 65 tokens, which the 16-frame model's positional
+        // table is sized for. Unbatched in, so one unbatched probability vector out.
+        var probabilities = model.Predict(Random(model.Architecture.GetInputShape(), seed: 1));
+
+        Assert.Equal(new[] { Classes }, probabilities.Shape.ToArray());
+    }
+
+    [Fact]
+    public void BlockPlainForward_GroupsTokensByTheDeclaredFrameCount()
+    {
+        var model = Small(ClipArchitecture(frames: 16));
+        var block = model.Layers.OfType<TimeSformerBlockLayer<double>>().First();
+
+        // A 16-frame clip's tokens: 1 CLS + 16 frames x 4 patches, 16 wide.
+        var tokens = Random([1, 1 + 16 * 4, 16], seed: 2);
+
+        // The frame-count-less Forward (used by anything that runs the layer on its own) must group the
+        // patch tokens into the same 16 frames the tokenizer produced, not the default 8.
+        var plain = block.Forward(tokens);
+        var explicitSixteen = block.Forward(tokens, 16);
+
+        Assert.Equal(explicitSixteen.Length, plain.Length);
+        for (int i = 0; i < plain.Length; i++)
+        {
+            Assert.Equal(explicitSixteen.Data.Span[i], plain.Data.Span[i], 12);
+        }
+    }
+
+    [Fact]
+    public void Constructor_ConflictingExplicitFrameCount_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => Small(ClipArchitecture(frames: 16), numFrames: 4));
+        Assert.Equal("numFrames", ex.ParamName);
+    }
+
+    [Fact]
+    public void Constructor_WithoutADeclaredFrameCount_KeepsTheNumFramesArgument()
+    {
+        var arch = new NeuralNetworkArchitecture<double>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputDepth: 3, inputHeight: Size, inputWidth: Size, outputSize: Classes);
+
+        Assert.Equal(4, Small(arch, numFrames: 4).NumFrames);
+    }
+
+    [Fact]
+    public void Predict_UnbatchedClip_ReturnsAnUnbatchedProbabilityVector()
+    {
+        var model = Small(ClipArchitecture(frames: 4));
+
+        // Classify documents [NumClasses] for a [T, C, H, W] clip, the output layout is batch-optional,
+        // and the base PredictCore squeezes the batch it adds. It returned [1, NumClasses].
+        var probabilities = model.Predict(Random([4, 3, Size, Size], seed: 3));
+
+        Assert.Equal(new[] { Classes }, probabilities.Shape.ToArray());
+    }
+
+    [Fact]
+    public void Predict_Batch_NormalisesEachClipSeparately()
+    {
+        var model = Small(ClipArchitecture(frames: 4));
+
+        var probabilities = model.Predict(Random([3, 4, 3, Size, Size], seed: 4));
+
+        // One probability vector per clip. The softmax used to run over the WHOLE [B, NumClasses] tensor,
+        // so the three rows summed to 1 together instead of each summing to 1.
+        Assert.Equal(new[] { 3, Classes }, probabilities.Shape.ToArray());
+        for (int b = 0; b < 3; b++)
+        {
+            double sum = 0;
+            for (int c = 0; c < Classes; c++)
+            {
+                double p = probabilities[b, c];
+                Assert.InRange(p, 0.0, 1.0);
+                sum += p;
+            }
+
+            Assert.Equal(1.0, sum, 9);
+        }
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingFidelityTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingFidelityTests.cs
@@ -1,0 +1,298 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.ActionRecognition;
+using AiDotNet.Video.Options;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.ActionRecognition;
+
+/// <summary>
+/// VideoMAE masked-autoencoder pretraining against the paper (Tong et al. 2022): it must actually train,
+/// its encoder must not see or process masked patches, gradients must reach every layer on the
+/// reconstruction path, and the target must be per-patch normalised pixels by default.
+/// </summary>
+/// <remarks>
+/// Layer indices follow the default stack: 0 patch-embed, 1-12 encoder blocks, 13 feature-reduce conv,
+/// 14 pool, 15 classifier, 16-19 decoder blocks, 20 reconstruction head.
+/// </remarks>
+public class VideoMAEPretrainingFidelityTests
+{
+    private const int PatchSize = 16;
+    private const int TubeletSize = 2;
+    private const int Channels = 3;
+    private const int Frames = 4;
+    private const int Size = 32;
+
+    private static NeuralNetworkArchitecture<double> VideoArch() => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: Frames,
+        inputDepth: Channels,
+        inputHeight: Size,
+        inputWidth: Size,
+        outputSize: 4);
+
+    private static VideoMAE<double> Model(double maskRatio = 0.5, VideoMAEOptions? options = null)
+        => new(VideoArch(), numClasses: 4, numFrames: Frames, numFeatures: 16, maskRatio: maskRatio, options: options);
+
+    private static Tensor<double> RandomClip(int seed)
+    {
+        var rng = new Random(seed);
+        var clip = new Tensor<double>([1, Frames, Channels, Size, Size]);
+        var span = clip.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return clip;
+    }
+
+    private static double[] LayerParameters(VideoMAE<double> model, int index)
+        => model.Layers[index].GetParameters().ToArray();
+
+    private static bool Changed(double[] before, double[] after)
+        => before.Length != after.Length || before.Where((v, i) => v != after[i]).Any();
+
+    /// <summary>
+    /// A clip whose every 16x16 patch repeats one random pattern (per frame and channel), so every masked
+    /// patch has the same reconstruction target whatever the mask - a fixed clip the model can
+    /// demonstrably learn in a few dozen steps, independent of which patches each step masks.
+    /// </summary>
+    private static Tensor<double> TiledClip(int seed)
+    {
+        var rng = new Random(seed);
+        var tile = new double[Frames, Channels, PatchSize, PatchSize];
+        for (int f = 0; f < Frames; f++)
+            for (int c = 0; c < Channels; c++)
+                for (int y = 0; y < PatchSize; y++)
+                    for (int x = 0; x < PatchSize; x++)
+                        tile[f, c, y, x] = rng.NextDouble();
+
+        var clip = new Tensor<double>([1, Frames, Channels, Size, Size]);
+        for (int f = 0; f < Frames; f++)
+            for (int c = 0; c < Channels; c++)
+                for (int y = 0; y < Size; y++)
+                    for (int x = 0; x < Size; x++)
+                        clip[0, f, c, y, x] = tile[f, c, y % PatchSize, x % PatchSize];
+        return clip;
+    }
+
+    [Fact]
+    public void PretrainMAE_UpdatesTheWeights_AndTheLossFallsOverStepsOnAFixedClip()
+    {
+        var model = Model();
+        var clip = TiledClip(seed: 21);
+
+        // Materialise the lazy decoder layers so their parameters exist to compare.
+        model.PretrainMAE(clip);
+        var headBefore = LayerParameters(model, VideoMAELayerLayout.ReconstructionHeadIndex);
+
+        var losses = new List<double>();
+        for (int step = 0; step < 60; step++)
+        {
+            losses.Add(model.PretrainMAE(clip));
+        }
+
+        // PretrainMAE used to compute the loss and return it, without back-propagating or stepping an
+        // optimizer: the weights never moved and the loss only varied with the random mask.
+        Assert.True(Changed(headBefore, LayerParameters(model, VideoMAELayerLayout.ReconstructionHeadIndex)),
+            "the reconstruction head did not change across 60 pretraining steps");
+
+        // Default Adam (lr 1e-3) on per-patch normalised targets: the loss starts near 1 (the target's
+        // variance) and falls steadily; measured 0.994 -> 0.893 over the first 40 steps.
+        double early = losses.Take(5).Average();
+        double late = losses.Skip(losses.Count - 5).Average();
+        Assert.True(late < 0.85 * early,
+            $"pretraining did not reduce the reconstruction loss on a fixed clip: first five steps averaged {early:G6}, "
+            + $"last five {late:G6} (all: {string.Join(", ", losses.Select(l => l.ToString("G4")))})");
+    }
+
+    [Fact]
+    public void PretrainMAE_ReachesEveryLayerOnTheReconstructionPath_AndNothingElse()
+    {
+        var model = Model();
+        var clip = RandomClip(seed: 22);
+
+        model.PretrainMAE(clip); // materialise lazy layers
+        var before = Enumerable.Range(0, model.Layers.Count).Select(i => LayerParameters(model, i)).ToArray();
+
+        model.PretrainMAE(clip);
+
+        // Patch embedding, all 12 encoder blocks, all 4 decoder blocks and the head are on the
+        // reconstruction path, so one step must move each of them. The decoder used to stack a
+        // Transform-based GELU after every block, which records no autodiff node: the loss reached the
+        // head and nothing before it.
+        var onPath = new List<int> { VideoMAELayerLayout.PatchEmbedIndex };
+        onPath.AddRange(Enumerable.Range(VideoMAELayerLayout.FirstEncoderBlockIndex, VideoMAELayerLayout.EncoderBlockCount));
+        onPath.AddRange(Enumerable.Range(VideoMAELayerLayout.FirstDecoderBlockIndex, VideoMAELayerLayout.DecoderBlockCount));
+        onPath.Add(VideoMAELayerLayout.ReconstructionHeadIndex);
+
+        var unchanged = onPath.Where(i => !Changed(before[i], LayerParameters(model, i))).ToList();
+        Assert.True(unchanged.Count == 0,
+            $"layers on the reconstruction path received no update: [{string.Join(", ", unchanged)}]");
+
+        // The classification head is not on the pretraining path and must be left alone.
+        foreach (int i in new[] { VideoMAELayerLayout.FeatureReduceIndex, VideoMAELayerLayout.ClassifierIndex })
+        {
+            Assert.False(Changed(before[i], LayerParameters(model, i)), $"classification-head layer {i} changed during pretraining");
+        }
+    }
+
+    [Fact]
+    public void EncodeVisiblePatches_LeavesEveryMaskedPatchEmpty_ThroughTheWholeEncoder()
+    {
+        var model = Model();
+        var clip = RandomClip(seed: 23);
+        int patches = Size / PatchSize;
+        int numTubelets = Frames / TubeletSize;
+
+        // Patches (0, 1) and (1, 0) masked; (0, 0) and (1, 1) visible.
+        var mask = new bool[1, patches, patches];
+        mask[0, 0, 1] = true;
+        mask[0, 1, 0] = true;
+
+        var features = model.EncodeVisiblePatches(clip, mask);
+        Assert.Equal(new[] { numTubelets, 16, patches, patches }, features.Shape.ToArray());
+
+        // The paper's encoder never processes masked tokens. The masked positions used to be zeroed once,
+        // at the embedding, and then refilled by every 3x3 block from their visible neighbours and the
+        // block bias, so the encoder processed them like any other token.
+        bool anyVisibleNonZero = false;
+        for (int t = 0; t < numTubelets; t++)
+        {
+            for (int c = 0; c < 16; c++)
+            {
+                for (int ph = 0; ph < patches; ph++)
+                {
+                    for (int pw = 0; pw < patches; pw++)
+                    {
+                        double v = features[t, c, ph, pw];
+                        if (mask[0, ph, pw])
+                        {
+                            Assert.True(v == 0.0, $"masked patch ({ph}, {pw}) of tubelet {t} channel {c} holds {v}");
+                        }
+                        else if (v != 0.0)
+                        {
+                            anyVisibleNonZero = true;
+                        }
+                    }
+                }
+            }
+        }
+
+        Assert.True(anyVisibleNonZero, "every visible feature was zero, so the check above proves nothing");
+    }
+
+    [Fact]
+    public void PretrainMAE_WithEveryPatchMasked_TeachesTheEncoderNothing()
+    {
+        // With every patch masked the encoder sees no content at all, so no gradient may reach the patch
+        // embedding or any encoder block. The masked embeddings used to be zeroed by an in-place write the
+        // tape never saw, so backward still carried gradient through them into the patch-embedding
+        // weights, weighted by the masked patches' own pixels - the content the model is meant to predict
+        // without seeing. The head, which learns to predict from nothing, must still move.
+        var model = Model(maskRatio: 1.0);
+        var clip = RandomClip(seed: 24);
+
+        model.PretrainMAE(clip); // materialise lazy layers
+        var before = Enumerable.Range(0, model.Layers.Count).Select(i => LayerParameters(model, i)).ToArray();
+
+        model.PretrainMAE(clip);
+
+        for (int i = VideoMAELayerLayout.PatchEmbedIndex; i < VideoMAELayerLayout.EncoderEndIndex; i++)
+        {
+            Assert.False(Changed(before[i], LayerParameters(model, i)), $"encoder layer {i} learned from fully masked input");
+        }
+
+        Assert.True(Changed(before[VideoMAELayerLayout.ReconstructionHeadIndex],
+            LayerParameters(model, VideoMAELayerLayout.ReconstructionHeadIndex)), "the reconstruction head did not train");
+    }
+
+    /// <summary>
+    /// The paper's per-patch normalised target, computed independently of the model: for each channel of
+    /// each tubelet patch, (x - mean) / (unbiased std + 1e-6) over its tubeletSize x P x P pixels, laid out
+    /// like the head's output.
+    /// </summary>
+    private static Tensor<double> NormalisedTarget(Tensor<double> clip)
+    {
+        int numTubelets = Frames / TubeletSize;
+        int patches = Size / PatchSize;
+        int patchDim = Channels * TubeletSize * PatchSize * PatchSize;
+        var target = new Tensor<double>([numTubelets, patchDim, patches, patches]);
+
+        for (int t = 0; t < numTubelets; t++)
+            for (int ph = 0; ph < patches; ph++)
+                for (int pw = 0; pw < patches; pw++)
+                    for (int c = 0; c < Channels; c++)
+                    {
+                        var values = new List<double>();
+                        for (int ts = 0; ts < TubeletSize; ts++)
+                            for (int y = 0; y < PatchSize; y++)
+                                for (int x = 0; x < PatchSize; x++)
+                                    values.Add(clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x]);
+
+                        double mean = values.Average();
+                        double std = Math.Sqrt(values.Sum(v => (v - mean) * (v - mean)) / (values.Count - 1));
+
+                        for (int ts = 0; ts < TubeletSize; ts++)
+                            for (int y = 0; y < PatchSize; y++)
+                                for (int x = 0; x < PatchSize; x++)
+                                {
+                                    int channel = (((ts * Channels) + c) * PatchSize + y) * PatchSize + x;
+                                    double v = clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x];
+                                    target[t, channel, ph, pw] = (v - mean) / (std + 1e-6);
+                                }
+                    }
+
+        return target;
+    }
+
+    [Fact]
+    public void ComputeReconstructionLoss_ByDefault_TargetsPerPatchNormalisedPixels()
+    {
+        var model = Model();
+        var clip = RandomClip(seed: 25);
+        int patches = Size / PatchSize;
+
+        var mask = new bool[1, patches, patches];
+        mask[0, 1, 1] = true;
+
+        // The paper (and its reference code's default normlize_target=True) reconstructs each patch's
+        // pixels normalised by that patch's own mean and standard deviation. The target used to be the
+        // raw pixels, with no option to normalise.
+        var normalised = NormalisedTarget(clip);
+        Assert.Equal(0.0, model.ComputeReconstructionLoss(normalised, clip, mask), 10);
+
+        // Raw pixels are therefore NOT a perfect prediction under the default.
+        var raw = new Tensor<double>(normalised.Shape.ToArray());
+        int numTubelets = Frames / TubeletSize;
+        for (int t = 0; t < numTubelets; t++)
+            for (int ts = 0; ts < TubeletSize; ts++)
+                for (int c = 0; c < Channels; c++)
+                    for (int y = 0; y < PatchSize; y++)
+                        for (int x = 0; x < PatchSize; x++)
+                            for (int ph = 0; ph < patches; ph++)
+                                for (int pw = 0; pw < patches; pw++)
+                                {
+                                    int channel = (((ts * Channels) + c) * PatchSize + y) * PatchSize + x;
+                                    raw[t, channel, ph, pw] = clip[0, t * TubeletSize + ts, c, ph * PatchSize + y, pw * PatchSize + x];
+                                }
+
+        Assert.True(model.ComputeReconstructionLoss(raw, clip, mask) > 0.1,
+            "raw pixels scored as a perfect prediction, so the default target is not normalised");
+
+        // Opting out restores the raw-pixel target exactly.
+        var rawModel = Model(options: new VideoMAEOptions { NormalizeTarget = false });
+        Assert.Equal(0.0, rawModel.ComputeReconstructionLoss(raw, clip, mask), 12);
+    }
+
+    [Fact]
+    public void Options_NormalizeTarget_DefaultsToThePapersChoice()
+    {
+        Assert.True(new VideoMAEOptions().NormalizeTarget);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/ActionRecognition/VideoMAEPretrainingTests.cs
@@ -94,7 +94,10 @@ public class VideoMAEPretrainingTests
     {
         const int frames = 4;
         const int size = 32;
-        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 8);
+        // Raw-pixel target, so the exact per-pixel correspondence is checkable by hand. The default
+        // (per-patch normalised) target is pinned in VideoMAEPretrainingFidelityTests.
+        var model = new VideoMAE<double>(VideoArch(frames, size), numClasses: 4, numFrames: frames, numFeatures: 8,
+            options: new AiDotNet.Video.Options.VideoMAEOptions { NormalizeTarget = false });
         var clip = RandomClip(frames, size, seed: 13);
 
         int numTubelets = frames / TubeletSize;

--- a/tests/AiDotNet.Tests/UnitTests/Video/Motion/OpticalFlowDeclaredInputTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/Motion/OpticalFlowDeclaredInputTests.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video;
+using AiDotNet.Video.Motion;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video.Motion;
+
+/// <summary>
+/// Optical-flow models must predict on a tensor of their own declared input shape.
+/// </summary>
+/// <remarks>
+/// <para>
+/// These models declare their input through the architecture as <c>InputType.ThreeDimensional</c> with
+/// <c>InputDepth = 6</c> - a frame PAIR stacked on the channel axis - so <c>GetInputShape()</c> is the
+/// unbatched <c>[6, H, W]</c>. Their shared <see cref="OpticalFlowBase{T}"/> <c>PredictCore</c> rejected
+/// every rank-3 input with "Input must be rank 4" instead of adding the batch axis, so none of them could
+/// run on the shape it advertises.
+/// </para>
+/// <para>
+/// A small spatial size and a narrow, shallow stack keep this cheap; the defect is independent of both.
+/// </para>
+/// </remarks>
+public class OpticalFlowDeclaredInputTests
+{
+    private const int Size = 16;
+
+    private static NeuralNetworkArchitecture<double> PairArchitecture(int depth = 6) => new(
+        inputType: InputType.ThreeDimensional,
+        taskType: NeuralNetworkTaskType.Regression,
+        inputHeight: Size, inputWidth: Size, inputDepth: depth,
+        outputSize: 2);
+
+    private static readonly Dictionary<string, Func<OpticalFlowBase<double>>> PairDeclaringModels = new()
+    {
+        ["DKM"] = () => new DKM<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["DPFlow"] = () => new DPFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["FlowDiffuser"] = () => new FlowDiffuser<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["FlowFormerPlusPlus"] = () => new FlowFormerPlusPlus<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["MemFlow"] = () => new MemFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["NeuFlowV2"] = () => new NeuFlowV2<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["RoMa"] = () => new RoMa<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["RPKNet"] = () => new RPKNet<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["SEARAFT"] = () => new SEARAFT<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["SKFlow"] = () => new SKFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["UFM"] = () => new UFM<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["UniMatch"] = () => new UniMatch<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+        ["VideoFlow"] = () => new VideoFlow<double>(PairArchitecture(), numFeatures: 8, numLayers: 2),
+    };
+
+    public static IEnumerable<object[]> PairDeclaringModelNames()
+        => PairDeclaringModels.Keys.Select(name => new object[] { name });
+
+    private static Tensor<double> Random(int[] shape, int seed)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<double>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = rng.NextDouble();
+        }
+        return t;
+    }
+
+    private static Tensor<double> WithBatchAxis(Tensor<double> unbatched)
+    {
+        var shape = new int[unbatched.Rank + 1];
+        shape[0] = 1;
+        for (int i = 0; i < unbatched.Rank; i++) shape[i + 1] = unbatched.Shape[i];
+        var batched = new Tensor<double>(shape);
+        unbatched.Data.Span.CopyTo(batched.Data.Span);
+        return batched;
+    }
+
+    private static void AssertSameValues(Tensor<double> expected, Tensor<double> actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var e = expected.Data.Span;
+        var a = actual.Data.Span;
+        for (int i = 0; i < e.Length; i++)
+        {
+            Assert.Equal(e[i], a[i], 10);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(PairDeclaringModelNames))]
+    public void Predict_OnTheDeclaredInputShape_ReturnsAnUnbatchedFlowField(string modelName)
+    {
+        var model = PairDeclaringModels[modelName]();
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 6, Size, Size }, declared);
+
+        var pair = Random(declared, seed: 5);
+        var flow = model.Predict(pair);
+
+        // Unbatched in, unbatched out: one [dx, dy] field at the input resolution.
+        Assert.Equal(new[] { 2, Size, Size }, flow.Shape.ToArray());
+
+        // And it is the SAME field the batched form produces for that one sample - the promotion adds
+        // an axis, it does not change the computation.
+        var batchedFlow = model.Predict(WithBatchAxis(pair));
+        Assert.Equal(new[] { 1, 2, Size, Size }, batchedFlow.Shape.ToArray());
+        AssertSameValues(batchedFlow, flow);
+    }
+
+    [Fact]
+    public void RAPIDFlow_PredictsOnAnUnbatchedFramePair()
+    {
+        // RAPIDFlow is the family's exception: its architecture's InputDepth is the PER-FRAME channel count
+        // (3), so its declared shape [3, H, W] describes one frame rather than the pair Predict takes (see
+        // the TestScaffoldGenerator note on RAPIDFlow). What the shared base owes it is the same as every
+        // other member: an unbatched pair [2*3, H, W] must be accepted, not rejected for its rank.
+        var model = new RAPIDFlow<double>(PairArchitecture(depth: 3), numRefinementIterations: 1);
+
+        var pair = Random([6, Size, Size], seed: 7);
+        var flow = model.Predict(pair);
+
+        Assert.Equal(new[] { 2, Size, Size }, flow.Shape.ToArray());
+        AssertSameValues(model.Predict(WithBatchAxis(pair)), flow);
+    }
+
+    [Fact]
+    public void RAFT_PredictsOnAnUnbatchedFramePair()
+    {
+        // RAFT overrides PredictCore but inherits the family's batch-optional input layout, so it owes the
+        // same unbatched pair [2*C, H, W]. It indexed Shape[3] unconditionally and threw IndexOutOfRange.
+        const int size = 32;
+        var model = new RAFT<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.ThreeDimensional,
+                taskType: NeuralNetworkTaskType.Regression,
+                inputHeight: size, inputWidth: size, inputDepth: 3,
+                outputSize: 2),
+            numFeatures: 16, correlationLevels: 2, correlationRadius: 1, numIterations: 1);
+
+        var pair = Random([6, size, size], seed: 9);
+        var flow = model.Predict(pair);
+
+        Assert.Equal(new[] { 2, size, size }, flow.Shape.ToArray());
+        AssertSameValues(model.Predict(WithBatchAxis(pair)), flow);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Video/VideoModelDeclaredInputTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Video/VideoModelDeclaredInputTests.cs
@@ -1,0 +1,213 @@
+using System;
+using System.Linq;
+using AiDotNet.Enums;
+using AiDotNet.NeuralNetworks;
+using AiDotNet.Tensors.LinearAlgebra;
+using AiDotNet.Video.Enhancement;
+using AiDotNet.Video.Generation;
+using AiDotNet.Video.Inpainting;
+using AiDotNet.Video.Options;
+using AiDotNet.Video.Understanding;
+using Xunit;
+
+namespace AiDotNet.Tests.UnitTests.Video;
+
+/// <summary>
+/// Video models must run on a tensor of their own declared input shape (<c>GetInputShape()</c>).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Each case here failed that probe for a model-specific reason, and each was judged on which side was
+/// wrong:
+/// </para>
+/// <list type="bullet">
+/// <item>BasicVSR++, OpenSora and ProPainter declare a single <c>[C, H, W]</c> frame or latent, which is a
+/// valid input under their own contracts (a one-frame clip; a single latent; a one-frame clip), but their
+/// Predict indexed a fourth axis it never added. Predict was wrong.</item>
+/// <item>VideoCLIP's input layout is <c>[Frames, C, H, W]</c> and it owns a clip length (<c>numFrames</c>),
+/// but its default architecture declared a single <c>[3, 224, 224]</c> frame. The declaration was
+/// wrong.</item>
+/// </list>
+/// </remarks>
+public class VideoModelDeclaredInputTests
+{
+    private static NeuralNetworkArchitecture<double> FrameArchitecture(int size) => new(
+        inputType: InputType.ThreeDimensional,
+        taskType: NeuralNetworkTaskType.Regression,
+        inputHeight: size, inputWidth: size, inputDepth: 3,
+        outputSize: 2);
+
+    private static Tensor<T> Random<T>(int[] shape, int seed, Func<double, T> convert)
+    {
+        var rng = new System.Random(seed);
+        var t = new Tensor<T>(shape);
+        var span = t.Data.Span;
+        for (int i = 0; i < span.Length; i++)
+        {
+            span[i] = convert(rng.NextDouble());
+        }
+        return t;
+    }
+
+    private static Tensor<double> Random(int[] shape, int seed) => Random(shape, seed, v => v);
+
+    private static Tensor<double> WithLeadingAxis(Tensor<double> tensor)
+    {
+        var shape = new int[tensor.Rank + 1];
+        shape[0] = 1;
+        for (int i = 0; i < tensor.Rank; i++) shape[i + 1] = tensor.Shape[i];
+        var result = new Tensor<double>(shape);
+        tensor.Data.Span.CopyTo(result.Data.Span);
+        return result;
+    }
+
+    private static void AssertSameValues(Tensor<double> expected, Tensor<double> actual)
+    {
+        Assert.Equal(expected.Length, actual.Length);
+        var e = expected.Data.Span;
+        var a = actual.Data.Span;
+        for (int i = 0; i < e.Length; i++)
+        {
+            Assert.Equal(e[i], a[i], 10);
+        }
+    }
+
+    [Fact]
+    public void BasicVSRPlusPlus_UpscalesItsDeclaredSingleFrame_AsAOneFrameClip()
+    {
+        const int size = 32;
+        var model = new BasicVSRPlusPlus<double>(
+            FrameArchitecture(size), scaleFactor: 2, numFeatures: 8, numResidualBlocks: 1, numPropagations: 1);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 3, size, size }, declared);
+
+        // It used to read [C, H, W] as a clip of C two-dimensional frames and fail inside the feature
+        // extractor / flow estimator.
+        var frame = Random(declared, seed: 1);
+        var upscaled = model.Predict(frame);
+
+        Assert.Equal(new[] { 3, size * 2, size * 2 }, upscaled.Shape.ToArray());
+
+        // Exactly the one-frame clip [1, C, H, W], without its frame axis.
+        var clip = model.Predict(WithLeadingAxis(frame));
+        Assert.Equal(new[] { 1, 3, size * 2, size * 2 }, clip.Shape.ToArray());
+        AssertSameValues(clip, upscaled);
+    }
+
+    [Fact]
+    public void OpenSora_DenoisesItsDeclaredSingleLatent()
+    {
+        const int size = 16;
+        var model = new OpenSora<double>(
+            new NeuralNetworkArchitecture<double>(
+                inputType: InputType.ThreeDimensional,
+                taskType: NeuralNetworkTaskType.Generative,
+                inputHeight: size, inputWidth: size, inputDepth: 3,
+                outputSize: size * size * 3),
+            numFrames: 2, hiddenDim: 32, numLayers: 1, numInferenceSteps: 4);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 3, size, size }, declared);
+
+        // The denoiser indexed axis 3 of its features, so a rank-3 latent threw IndexOutOfRange.
+        var latent = Random(declared, seed: 2);
+        var denoised = model.Predict(latent);
+
+        Assert.Equal(new[] { 3, size, size }, denoised.Shape.ToArray());
+        AssertSameValues(model.Predict(WithLeadingAxis(latent)), denoised);
+    }
+
+    [Fact]
+    public void ProPainter_ReconstructsItsDeclaredSingleFrame_AsAOneFrameClip()
+    {
+        const int size = 16;
+        var model = new ProPainter<double>(FrameArchitecture(size), numFeatures: 8, numTransformerBlocks: 1, numHeads: 2);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 3, size, size }, declared);
+
+        // The image path read axis 3, so a rank-3 frame threw IndexOutOfRange.
+        var frame = Random(declared, seed: 3);
+        var reconstructed = model.Predict(frame);
+
+        Assert.Equal(3, reconstructed.Rank);
+        Assert.Equal(new[] { size, size }, reconstructed.Shape.ToArray().Skip(1).ToArray());
+        AssertSameValues(model.Predict(WithLeadingAxis(frame)), reconstructed);
+    }
+
+    [Fact]
+    public void VideoCLIP_DefaultConstructor_DeclaresTheClipItEncodes()
+    {
+        using var model = new VideoCLIP<float>();
+
+        // Its input layout is [Frames, C, H, W] and its default clip is 32 frames; it used to declare a
+        // single [3, 224, 224] frame (InputType.ThreeDimensional), which EncodeVideo cannot take.
+        Assert.Equal(InputType.FourDimensional, model.GetArchitecture().InputType);
+        Assert.Equal(new[] { 32, 3, 224, 224 }, model.GetArchitecture().GetInputShape());
+        Assert.Equal(32, model.NumFrames);
+    }
+
+    private static VideoCLIP<float> SmallVideoCLIP(NeuralNetworkArchitecture<float> architecture, int? numFrames = null)
+    {
+        var options = new VideoCLIPVideoOptions
+        {
+            HiddenDimension = 32,
+            NumSpatialBlocks = 1,
+            NumTemporalBlocks = 1,
+            NumTextBlocks = 1,
+            WarmupSteps = 0,
+        };
+
+        return numFrames is int frames
+            ? new VideoCLIP<float>(architecture, numFrames: frames, embeddingDim: 4, textMaxLength: 8, vocabSize: 64, options: options)
+            : new VideoCLIP<float>(architecture, embeddingDim: 4, textMaxLength: 8, vocabSize: 64, options: options);
+    }
+
+    private static NeuralNetworkArchitecture<float> ClipArchitecture(int frames) => new(
+        inputType: InputType.FourDimensional,
+        taskType: NeuralNetworkTaskType.MultiClassClassification,
+        inputFrames: frames, inputDepth: 3, inputHeight: 32, inputWidth: 32,
+        outputSize: 4);
+
+    [Fact]
+    public void VideoCLIP_TakesTheArchitecturesFrameCount_AndPredictsOnTheDeclaredClip()
+    {
+        using var model = SmallVideoCLIP(ClipArchitecture(frames: 4));
+
+        Assert.Equal(4, model.NumFrames);
+        Assert.Equal(4, model.GetModelMetadata().AdditionalInfo["NumFrames"]);
+
+        int[] declared = model.GetArchitecture().GetInputShape();
+        Assert.Equal(new[] { 4, 3, 32, 32 }, declared);
+
+        var embedding = model.Predict(Random(declared, seed: 4, v => (float)v));
+        Assert.Equal(4, embedding.Length); // one embeddingDim-wide vector for the one clip
+    }
+
+    [Fact]
+    public void VideoCLIP_DeclaringTheClip_DoesNotChangeTheResolvedLayerStack()
+    {
+        // The layer stack runs per frame, and its lazy layers are resolved ahead of the first forward
+        // from the architecture's declared input. Declaring the clip [Frames, C, H, W] instead of one frame
+        // must not leave the stack unresolved: ParameterCount at construction (which weight-streaming and
+        // other memory decisions read) has to match the one-frame declaration's.
+        var frameArchitecture = new NeuralNetworkArchitecture<float>(
+            inputType: InputType.ThreeDimensional,
+            taskType: NeuralNetworkTaskType.MultiClassClassification,
+            inputDepth: 3, inputHeight: 32, inputWidth: 32, outputSize: 4);
+
+        using var declaredAsFrame = SmallVideoCLIP(frameArchitecture, numFrames: 4);
+        using var declaredAsClip = SmallVideoCLIP(ClipArchitecture(frames: 4));
+
+        Assert.True(declaredAsFrame.ParameterCount > 0);
+        Assert.Equal(declaredAsFrame.ParameterCount, declaredAsClip.ParameterCount);
+    }
+
+    [Fact]
+    public void VideoCLIP_ConflictingExplicitFrameCount_Throws()
+    {
+        var ex = Assert.Throws<ArgumentException>(() => SmallVideoCLIP(ClipArchitecture(frames: 4), numFrames: 8));
+        Assert.Equal("numFrames", ex.ParamName);
+    }
+}


### PR DESCRIPTION
## Summary

The follow-up work PR #2174 listed as "what this does not do". Four commits, all root-cause fixes in the library, each with a regression test that was **proven to fail against the unfixed source** (method below).

**This PR is based on `fix/videomae-pretraining-and-timesformer` (PR #2174), which is still open at `4dedc7599`.** It is not based on `master`; merge #2174 first, or retarget this once #2174 lands. Every line number below is in the **unfixed** file at that base commit.

Four groups of defects:

1. **13 optical-flow models could not `Predict` on their own declared input shape** — their shared base rejected every unbatched input.
2. **Seven more video models failed the same declared-shape probe** for model-specific reasons; five are fixed, four are a decision for you (own section below).
3. **TimeSformer ignored `Architecture.InputFrames`**, and had two output-convention bugs (one of them a real numerical bug: a batch softmax).
4. **VideoMAE's masked-autoencoder pretraining never trained**, leaked masked content into the encoder's gradient, severed its own decoder tape, and had no per-patch target normalisation.

---

## 1. Optical flow: `Predict` on the declared shape

**Root cause:** `src/Video/OpticalFlowBase.cs:331` threw `"Input must be rank 4 [batch, 2*channels, height, width], got rank 3."` for any rank-3 input. Thirteen models declare their architecture as `InputType.ThreeDimensional` with `InputDepth = 6` (a frame PAIR stacked on the channel axis), so `GetInputShape()` is the unbatched `[6, H, W]` — the shape the model advertises is exactly the shape its `Predict` refused.

Affected: DKM, DPFlow, FlowDiffuser, FlowFormer++, MemFlow, NeuFlowV2, RoMa, RPKNet, SEA-RAFT, SKFlow, UFM, UniMatch, VideoFlow. RAPIDFlow hit the same check with an unbatched pair.

**Fix** (`PredictCore`): a rank-3 `[2*C, H, W]` pair is promoted with the established shared helper `NeuralNetworkBase.PromoteToBatchedTensor`, and the unit batch axis is squeezed back off the flow with a recorded `Engine.Reshape` — unbatched in, unbatched out, the same rule the base `PredictCore` applies to every model that inherits it (`NeuralNetworkBase.cs:6385` promote / `:6434` squeeze). The rank-4 body moved into a private `PredictBatchedPair`, so the batched path is byte-for-byte the same computation.

The declaration was brought in line with the code: both family `[TensorLayout]`s are now `BatchOptional = true`, and `OutputAxesFor` answers rank 3 (`[Channels=Fixed(2), Height=Same, Width=Same]`). Without that, the base would have accepted a rank the type does not declare.

**RAFT** (`src/Video/Motion/RAFT.cs:267`) overrides `PredictCore` but inherits that layout, so it owes the same contract: it sliced `input.Shape[3]` unconditionally and threw `IndexOutOfRangeException` on an unbatched pair. It now promotes/squeezes the same way, and a non-3/4 rank gets a clear `ArgumentException` instead of an index crash.

| | before | after |
|---|---|---|
| 13 pair-declaring models, `Predict(GetInputShape())` | `ArgumentException: Input must be rank 4 …` | `[2, H, W]`, equal element-for-element to the batched `[1, 2, H, W]` |
| RAPIDFlow, unbatched pair `[6, H, W]` | same `ArgumentException` | `[2, H, W]` |
| RAFT, unbatched pair `[6, H, W]` | `IndexOutOfRangeException` | `[2, H, W]` |

---

## 2. The seven model-specific declared-shape failures

| Model | Verdict | What changed |
|---|---|---|
| **BasicVSR++** | **Predict wrong** — `src/Video/Enhancement/BasicVSRPlusPlus.cs:542` read `[C,H,W]` as a clip of `C` two-dimensional frames, so the feature extractor got a rank-2 "frame" (`ConvolutionalLayer expects rank-3 … got rank 2`) | `EnhanceVideo` treats `[C,H,W]` as the **one-frame clip** the super-resolution family layout already documents ("A single low-resolution frame - the degenerate one-frame clip"), runs it as `[1,C,H,W]` and returns `[C, sH, sW]`. Recorded reshapes, so training through a single frame keeps its gradient path |
| **OpenSora** | **Predict wrong** — `src/Video/Generation/OpenSora.cs:350`; the denoiser indexes axis 3 of its features, so a rank-3 latent threw `IndexOutOfRangeException` | denoises a rank-3 latent as a batch of one and returns it without the batch axis, the same promotion the model already applies to single images elsewhere |
| **ProPainter** | **Predict wrong** — `src/Video/Inpainting/ProPainter.cs:270`; the image path indexes axis 3, `IndexOutOfRangeException` | runs a rank-3 frame as a one-frame clip (frames are reconstructed independently — the frame axis acts as the batch) and squeezes back |
| **VideoCLIP** | **declared shape wrong** — `src/Video/Understanding/VideoCLIP.cs:187` declared one `[3,224,224]` frame although the model's input layout is `[Frames, C, H, W]` and it owns a clip length (`numFrames`, default 32); `EncodeVideo` → `AddBatchDimension5D` threw `IndexOutOfRangeException` | default ctor declares `FourDimensional` with `inputFrames: 32`; `numFrames` (`:238`) is now resolved from the architecture when it declares one, with a conflicting explicit value rejected — the same rule VideoMAE and TimeSformer use |
| **RAFT** | **unresolved** (see next section) | only the rank-3 pair promotion from item 1 |
| **GMFlow** | **unresolved** (see next section) | nothing |
| **RIFE** | **unresolved** (see next section) | nothing |

---

## ⚠ DECISION NEEDED: four models whose declared shape cannot be fixed without a contract change

**RAFT, GMFlow, RAPIDFlow and RIFE still fail the declared-shape probe, deliberately.** All four document `Architecture.InputDepth` as the **per-frame** channel count, so their declared shape is ONE frame (`[3, H, W]`) while `Predict` needs a stacked PAIR (`[6, H, W]`). `GetInputShape()` is derived from the architecture, so there is no way to make the declared shape the pair without redefining what `InputDepth` means for these models — a public constructor argument's meaning.

The evidence that this is a deliberate, documented contract and not an oversight:

* **RAFT** — `_channels = architecture.InputDepth` (`RAFT.cs:176`); its `<example>` passes `inputDepth: 3`; `VideoExtendedIntegrationTests.RAFT_InputChannels_DefaultsToThree` asserts `InputChannels == 3` for a depth-3 architecture; the generated fixture builds it with `inputDepth: 3` and feeds `[1,6,64,64]`; `SEARAFT.cs:78-81` explicitly excludes RAFT and GMFlow from the "declare depth 6" rule because they have a separate 3-channel context encoder.
* **GMFlow** — same split (`GMFlow.cs:153`), same `inputDepth: 3` example and fixture.
* **RAPIDFlow** — `TryGetArchitectureInputShape() => null` with a doc comment stating "`Architecture.InputDepth` itself reports the SINGLE-FRAME count (3)", and `TestScaffoldGenerator.cs:9545-9547` states the same in the fixture comment.
* **RIFE** — this is the **frame-interpolation family's** documented rule, not RIFE's own: `FrameInterpolationBase.cs:171-184`, RIFE's ctor comment, its `<example>`, and the generator's fixture note all define `InputDepth` as per-frame. Changing it touches ~21 models (and `FILM`'s fixture already contradicts the family doc by passing `inputDepth: 6`, so the family is already inconsistent).

Changing `InputDepth` to mean the stacked pair for these four is a coherent option (13 of the 17 flow models already do it, and `OpticalFlowBase`'s note now says "most of the family"), but it would flip a documented public contract, break the assertions above, and for RIFE reverse a whole family's rule. Per the "user has final say on scope decisions" rule I stopped at evidence + recommendation. **Recommended:** adopt "InputDepth = 2×channels" for RAFT, GMFlow and RAPIDFlow (changing `_channels = InputDepth / 2` and the fixtures in lockstep so parameter counts do not move), and treat the frame-interpolation family separately as its own decision.

---

## VideoCLIP: a latent bug the declared-shape change exposed

With **any** `FourDimensional` architecture — not just the new default — the base lazy-shape walk (`NeuralNetworkBase.ResolveLazyLayerShapes`, `:5542`) starts from a rank-5 clip that VideoCLIP's first convolution rejects, so the stack is left unresolved until the first forward and `ParameterCount` under-reports at construction:

| default `new VideoCLIP<float>()` | `ParameterCount` at construction |
|---|---|
| before (declared one frame, walk happened to work) | **211,126,273** |
| after the declared-shape change, without the walk fix | **38,004,480** |
| after the walk fix (this PR) | **211,126,273** |

That matters beyond cosmetics: `ParameterCount` is what the weight-streaming auto-detect, `ShouldUseStreamingTraining` and `ConfigureInferenceForScale` gate on — the base class's own comment on that walk calls out that an under-reported count "blinded every ParameterCount-gated memory decision". VideoCLIP now overrides `TryGetArchitectureInputShape()` to return one frame `[1, C, H, W]`, because its layer stack genuinely runs per frame (the spatial encoder consumes frames, not clips). Precedent for the override: `RAPIDFlow`, `UFM`, `DPFlow`, `MiDaS`, `FrameInterpolationBase`, `Transformer`, `PANNsModel`.

Regression test `VideoCLIP_DeclaringTheClip_DoesNotChangeTheResolvedLayerStack` (small config): before **2,304** parameters vs **50,477** for the equivalent one-frame declaration; after, both 50,477.

---

## 3. TimeSformer

**Frame count.** `src/Video/ActionRecognition/TimeSformer.cs:223` set `_numFrames = numFrames` (default 8) and ignored `Architecture.InputFrames`, so a 16-frame architecture built an 8-frame model: `NumFrames` and metadata said 8, the positional table was sized `8 * patches + 1`, and — because the blocks are constructed with that count — `TimeSformerBlockLayer.Forward(input)` (the frame-count-less overload used whenever the layer is run on its own) grouped a 16-frame token sequence into 8 frames. It now applies VideoMAE's rule; the ONNX constructor's hard-coded `_numFrames = 8` (`:263`) reads the architecture too.

The rule moved into a new internal `src/Video/VideoClipFrameCount.cs` shared by VideoMAE, TimeSformer and VideoCLIP: *the architecture's declared count wins; an explicit non-default `numFrames` that disagrees throws `ArgumentException(nameof(numFrames))`*. VideoMAE's behaviour is unchanged (it delegates to the helper; its 10 existing tests still pass).

**Unbatched output.** `Classify` returned `[1, NumClasses]` for a `[T,C,H,W]` clip. Its own XML doc says `[NumClasses]`, the model's output `[TensorLayout]` is `BatchOptional`, and the base `PredictCore` squeezes the batch it adds — three statements of the same convention. Now squeezed (tokenized path only; a caller-supplied layer stack is left untouched).

**Batch softmax (numerical bug).** `TimeSformer.cs:401`'s hand-rolled softmax took the max and the sum over **every element** of the logits tensor, so for a batch of B clips the whole `[B, NumClasses]` matrix summed to 1 rather than each row: each clip's "probabilities" were scaled by how confident the other clips in the batch happened to be. Measured on a 3-clip batch: **row sum 0.325** instead of 1.0. Replaced with `Engine.Softmax` over the class axis.

Also moved the native constructor's XML docs, which were attached to the parameterless constructor (two `<summary>` blocks in a row), onto the constructor they describe, and documented `numFrames` and `options`.

Default parameter count unchanged: **113,541,120**.

---

## 4. VideoMAE pretraining fidelity (Tong et al. 2022)

**(a) `PretrainMAE` never trained.** `src/Video/ActionRecognition/VideoMAE.cs:345` computed a reconstruction loss and returned it — no backward, no optimizer step. The class docs, the `<example>`, and the name all describe pretraining, so it is meant to train. It now records the masked forward and the loss on a `GradientTape` and steps through `BackwardAndStepOnPrecomputedLoss` — the library's caller-owned-tape training entry point used by NeRF, TVAE, TabDDPM and the GANs — with the constructor's optimizer or the model's default Adam. The loss is now built from engine ops (subtract → square → multiply by a 0/1 masked-patch tensor → sum → scale) so it back-propagates; `ComputeReconstructionLoss` returns that same objective's value under a `NoGradScope`.

Measured on a fixed clip (small config: 4 frames, 32×32, 16 features, mask ratio 0.5, default Adam lr 1e-3):

| | before | after |
|---|---|---|
| reconstruction head parameters after 60 steps | unchanged | changed |
| loss over 40 steps | flat (varies only with the random mask) | **0.994 → 0.893**, falling monotonically |

**Which layers update** (one step, verified per layer): patch embedding (0), all 12 encoder blocks (1-12), all 4 decoder blocks (16-19) and the reconstruction head (20) — and **not** the classification head (13 feature-reduce, 15 classifier), which is not on the pretraining path. Before: none of them.

**(b) Masked tokens were zeroed, not dropped.** `VideoMAE.cs:743` wrote zeros into the patch embedding **in place**, once. Two defects followed:

* The 3×3 encoder blocks immediately refilled every masked position from its visible neighbours plus the block bias, so from the second block on the encoder was processing masked positions as ordinary tokens (measured: masked patch feature = 1.7e-3, not 0).
* The in-place write is invisible to the autodiff tape, so the backward pass still routed gradient through the embedding's masked outputs into the patch-embedding weights — **weighted by the masked patches' own pixels**, i.e. the content the model is supposed to predict without seeing.

The paper's encoder drops masked tokens; a convolution over the patch grid cannot drop grid positions. So it is made sparse the way masked-image-modelling work on convolutional encoders does it (SparK, Tian et al. 2023; ConvNeXt V2's FCMAE, Woo et al. 2023): a recorded visibility mask multiplies the patch embedding and the output of **every** encoder block. A masked position then holds exactly zero at every block input — it contributes nothing to its visible neighbours (identical to zero padding) and never accumulates a value or a gradient of its own.

**Deliberate deviation from the paper:** the learned mask token is **not** added. It would be a new trainable parameter (and would change every default parameter count), so masked positions enter the decoder as a fixed **zero** "mask token" and the decoder's convolutions fill them from the visible context. This is documented on `EncodeVisiblePatches` and in the class remarks rather than left implicit.

**(c) Tape-severing GELU in the decoder.** `VideoMAE.cs:792` stacked a `Tensor.Transform`-based GELU on every decoder block's own ReLU. `Transform` records no autodiff node, so it severed the tape after every block: a reconstruction loss could reach the head and nothing before it — no decoder block, no encoder block, no patch embedding. It was also numerically redundant (GELU of a non-negative ReLU output). Removed — the identical defect had already been fixed in the encoder on the base branch.

**(d) No per-patch target normalisation.** The target was raw pixels (`ComputeReconstructionLoss`, `:828`). New `VideoMAEOptions.NormalizeTarget`, **defaulting to `true`** — the paper's `normlize_target` default, inherited from MAE (He et al. 2022, §4) — normalises every channel of every tubelet patch over its own `tubeletSize × 16 × 16` pixels as `(x - mean) / (std + 1e-6)` with the **unbiased** standard deviation, exactly the reference implementation's `b (t h w) (p0 p1 p2) c` view reduced over `p0 p1 p2`. Setting it to `false` restores the raw-pixel target bit-exactly (the existing exact-value test now pins that path). Documented on the option, on `ComputeReconstructionLoss`, on the target builder and in the class remarks.

No parameters are added anywhere: default VideoMAE parameter count unchanged at **65,788,816**.

---

## Test results (net10.0, Release)

Baseline = this branch's base commit `4dedc7599`; "after" = this PR's head. Same machine, same filter.

| Suite | Before | After |
|---|---|---|
| Generated model-family suites: VideoMAE, TimeSformer, VideoCLIP, all 17 optical-flow models, RIFE, BasicVSR++, ProPainter | 783 passed, 23 skipped, **1 failed** | 783 passed, 23 skipped, **1 failed** — per-class counts identical |
| `TracedChainValidationTests` | 3 passed, **1 failed** (VideoMAE) | 3 passed, **1 failed** (VideoMAE) |
| New regression tests (35) | **33 failed**, 2 passed | **35 passed** |
| `VideoExtendedIntegrationTests` | – | 83 passed |
| `RAPIDFlowReviewRegressionIntegrationTests` | – | 3 passed |
| `ShapeContractConformanceTests` | – | 28 passed |
| `TensorLayoutRankTests` | – | 12 passed |

**Neither failure is a regression.** Both are the same single test, `TracedChainValidationTests.TracedValidationClearsTheFalsePositivesTheLinearReadingProduces(modelName: "VideoMAE")`, failing identically before and after with `System.ArgumentOutOfRangeException : Inner left-operand block exceeds its span. (Parameter 'aBase')`. That is the one-frame default-constructor crash **owned by the never-run-tests PR**; PR #2174 already documented it and deliberately kept clear of those lines, and so does this PR.

The 2 new tests that pass before the fix are guards, not evidence: TimeSformer's "no declared frame count keeps the `numFrames` argument" and the options default (which reads the stub described below).

**`ModelFamilyLawTests.DoTheMembersOfAFamilyShareOneShapeLaw` timed out locally after its own 30-minute limit, so I have no before/after for it.** It is the whole-model-zoo sweep (~900 constructions) that is known to time out unreliably on a local box; it was not part of the baseline run either, so I am reporting it as unmeasured rather than as a pass or a failure. CI is the arbiter for that one.

### How the fails-before numbers were produced

`git stash push --include-untracked -- src` (source only, tests left in place), then two **API-surface-only** stubs re-applied to the unfixed source so the new tests compile against the old logic:

* `VideoMAE.EncodeVisiblePatches` `private` → `internal` (visibility, no behaviour),
* an **unread** `VideoMAEOptions.NormalizeTarget` property (the unfixed model never looks at it).

Then a full rebuild and run. Afterwards the stash was popped and the restored working tree was verified **byte-identical** to the tested tree (`git diff` vs the saved patch: identical; the new helper file compared byte-for-byte). The numbers above come from that run: 33 of 35 new tests fail against the unfixed source with the exact errors quoted in the per-item sections.

### Builds

`src/AiDotNet.csproj` compiles with **0 errors for net10.0, net8.0 and net471** (the library multi-targets all three; net471 lacks several modern BCL APIs, so it is built explicitly).

---

## Adversarial review

**Default parameter counts** (measured, before → after): VideoMAE 65,788,816 → 65,788,816 · TimeSformer 113,541,120 → 113,541,120 · VideoCLIP 211,126,273 → 211,126,273 (would have been 38,004,480 without the walk fix) · RAFT 6,277,122 → 6,277,122 · SKFlow 300,098 → 300,098 · ProPainter 22,008,067 → 22,008,067 · BasicVSR++ 0 → 0 (fully lazy).

**Clone / serialize:**

* VideoMAE — clone preserves parameters, `NumFrames` **and** `NormalizeTarget`; the clone can run `PretrainMAE`; serialize → deserialize preserves parameters, `NormalizeTarget`, and produces bit-identical predictions.
* TimeSformer (16-frame architecture) — clone preserves parameters and now `NumFrames = 16` (before: 16 → **8**), and deserialize now yields an **identical prediction** (before: *different*, because the rebuilt model's frame count came back as 8 and re-grouped the tokens).
* VideoCLIP — clone preserves parameters and `NumFrames`.
* SKFlow — clone predicts the same unbatched `[2,16,16]` (before: the clone threw the rank-4 `ArgumentException`).

---

## Blast radius / file map

**Source (10 files, all under `src/Video`)**

| File | Change |
|---|---|
| `Video/OpticalFlowBase.cs` | rank-3 promotion + squeeze in `PredictCore`; body split into `PredictBatchedPair`; both `[TensorLayout]`s `BatchOptional`; `OutputAxesFor(3)` |
| `Video/Motion/RAFT.cs` | rank-3 promotion + squeeze; explicit rank guard |
| `Video/ActionRecognition/TimeSformer.cs` | frame count from the architecture; unbatched squeeze; per-clip softmax; ctor doc-comment placement |
| `Video/ActionRecognition/VideoMAE.cs` | pretraining step; sparse masking; decoder GELU removed; tape-built objective + normalised target; delegates frame resolution |
| `Video/Options/VideoMAEOptions.cs` | new `NormalizeTarget` option (default `true`) |
| `Video/VideoClipFrameCount.cs` | **new**: the one frame-count rule, internal |
| `Video/Enhancement/BasicVSRPlusPlus.cs` | one-frame clip in `EnhanceVideo` |
| `Video/Generation/OpenSora.cs` | rank-3 latent in `PredictCore` |
| `Video/Inpainting/ProPainter.cs` | rank-3 frame in `PredictCore` |
| `Video/Understanding/VideoCLIP.cs` | declared clip shape; frame count from the architecture; per-frame `TryGetArchitectureInputShape` |

Nothing outside `src/Video` is touched — no change to `NeuralNetworkBase`, `LayerHelper`, the generators or any shared layer. No visibility was widened beyond one `private` → `internal` inside `VideoMAE` for its own test (the same pattern the base branch already uses for `DecodeForReconstruction`, `CreateTubeMask` and `ComputeReconstructionLoss`).

**Tests (5 files)**: new `UnitTests/Video/Motion/OpticalFlowDeclaredInputTests.cs` (15), `UnitTests/Video/VideoModelDeclaredInputTests.cs` (7), `UnitTests/Video/ActionRecognition/TimeSformerFrameCountTests.cs` (7), `UnitTests/Video/ActionRecognition/VideoMAEPretrainingFidelityTests.cs` (6); plus `VideoMAEPretrainingTests.cs` — one existing exact-value test now constructs the model with `NormalizeTarget = false`, because it pins the raw-pixel correspondence by hand; the normalised default is pinned by a new test.

**Behavioural changes callers could notice (all of them the point of the PR):** unbatched optical-flow `Predict` now returns `[2,H,W]` instead of throwing; TimeSformer's unbatched `Predict` returns `[classes]` instead of `[1, classes]`; a batched TimeSformer `Predict` returns per-clip probabilities instead of batch-normalised ones; `PretrainMAE` now mutates weights and its loss is on normalised targets by default; a 16-frame TimeSformer / VideoCLIP architecture now builds a 16-/N-frame model instead of silently using the default.

---

## What this does not do

Found while working, **not fixed here** — each needs its own change and its own test:

* `VideoMAE.Train` calls `TrainWithTape(input, expectedOutput)` without the constructor's `_optimizer`, so a user-supplied optimizer is silently ignored (604 other call sites pass it; TimeSformer does). `PretrainMAE` in this PR does use it. Left out because a regression test needs a non-fusable optimizer probe to observe which optimizer actually ran.
* OpenSora's `[TensorLayout(Input)]` is `[Batch, Time, Features]` while `PredictCore` takes `[B, C, H, W]`, and its `Train` computes a gradient it never back-propagates. Its default config is ~446M parameters, so the declared-shape probe is only practical at a small config.
* ProPainter's inference always applies an all-zero mask, so `Predict` never actually inpaints anything.
* BasicVSR++ reads rank 4 as `[F, C, H, W]` while the inherited super-resolution layout says `[B, C, H, W]`; and `VideoSuperResolutionBase.EstimateFlow` defaults to an untrained full-size `new RAFT<T>()`, so every VSR model that does not override it aligns frames with random flow.
* GMFlow's rank-3 pair path splits `Shape[0] / 2` with no even-channel check.

Plus the four declared-shape models in the decision section above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
