### PR TITLE
feat(evolution): verify raw observations before fitness reuse

### DIFF
--- a/docs/PROGRAM_SAMPLE_EVIDENCE.md
+++ b/docs/PROGRAM_SAMPLE_EVIDENCE.md
@@ -1,0 +1,61 @@
+# Retained raw scalar observations for persistent program fitness
+
+`DirectoryProgramSampleEvidenceStore` is an opt-in implementation of
+`IProgramMeasurementEvidenceStore` for repeated scalar fitness measurements. It stores
+individual sample IDs and values, not just a hash of an aggregate. Use it with
+`PersistentProgramFitnessEvaluator`; keep the engine's `EnableEvaluationCache = false`
+so run-local memoization cannot bypass current freshness/correctness checks.
+
+The caller supplies genuine observations through a bounded, thread-safe capture callback.
+`ProgramMeasurementStatistics.Calculate` computes an arithmetic mean and sample standard
+error using 2–256 distinct observations. Use its `Version` in `EvolutionMeasurementOrigin`,
+with the same ordered original sample IDs, observation time, acquisition cost and standard
+error. The provider declines other statistics policies, confidence intervals, single samples,
+infeasible outcomes and summaries that do not reproduce from the raw observations.
+Different domains can implement the existing evidence-store interface with their own
+explicit verification policies.
+
+```csharp
+var evidence = new DirectoryProgramSampleEvidenceStore(
+    absolutePrivateDirectory,
+    "my-evaluator-observation-schema-v1",
+    async (program, measured, context, cancellation) =>
+        await observations.ReadOriginalSamplesAsync(
+            measured.MeasurementOrigin!.SampleIds, cancellation),
+    maximumEntries: 4096);
+```
+
+`observations` above is caller-owned acquisition storage, not a built-in service. The
+callback must return the actual `IReadOnlyList<ProgramMeasurementObservation>` behind
+that measurement, or null; do not fabricate repeated values from a mean. The provider
+does not execute program text, call models, start services or acquire samples during reuse.
+
+On reuse it reopens the content-addressed file, verifies exact bytes against SHA256,
+rejects ambiguous JSON, validates candidate codec bytes and all bound result/origin
+metadata, and recomputes mean/standard error. Current evaluation cost and diagnostic
+bodies are excluded from the binding: original acquisition cost stays in the origin,
+whereas a cache lookup is not a new independent measurement. Scalar observations verify
+scalar fitness; descriptors, objectives and metrics are bound metadata, not independent
+measurements of those other quantities. Correctness remains outside the fitness cache
+and runs on every facade dispatch.
+
+Files are atomic, write-once and at most 2 MiB. Capacity refusal does not evict old evidence.
+Cooperating writers use a short-lived exclusive `.writer.lock` handle; contention throws
+`IOException`, which the existing decorator treats as unavailable persistence. There is
+no unbounded waiting or retry loop. The marker is retained, while the OS releases the
+handle on process exit. Equivalent writers must use the same private directory and
+capacity policy. `HasTemporaryCleanupFailure` reports a failed cleanup without replacing
+the original publication outcome. Protect the directory from hostile writers and aliases;
+hashes do not authenticate a producer or attest hardware, stationarity or independence.
+
+The facade meters `program_evidence_invocations` and `cache_store_invocations` as logical
+method calls. Actual filesystem bytes/time, sample acquisition and callback costs require
+separate caller accounting. A standard error assumes independent samples but cannot
+establish that assumption; force fresh measurement for confirmation and never treat cache
+hits or deterministic replay as additional statistical power.
+
+Local contracts cover reopened storage, current correctness, force-fresh and expired
+measurements, missing/corrupt raw artifacts, fabricated means/uncertainty, changed sample
+identity/provider/candidate, capacity, cancellation, contention, strict JSON, byte limits
+and finite statistics. Source-linked checks are a fast diagnostic only: the full AiDotNet
+build's global imports/dependencies must also compile and pass the integration suite.

--- a/docs/evidence/raw-program-samples/d9eb58f/README.md
+++ b/docs/evidence/raw-program-samples/d9eb58f/README.md
@@ -1,0 +1,46 @@
+# US-23 raw program measurement evidence
+
+Implementation: `d9eb58f46e1f97c3bb300dea0c5e2b70f1321964`; explicit local core dependency:
+`255feb24369702a32ea9db7a3f8a0b7a847d2762` (US-10, including the US-08 reused-learning guard).
+No source changes separate these tested provider files from this evidence commit.
+
+The full evolution integration project passed **963/963 tests on .NET 10 and .NET 8**,
+zero skips. The actual .NET Framework 4.7.1 AiDotNet assembly passed **22/22 provider
+tests**, using the archived small test project rather than source-linked replacement
+provider types. The full legacy library build also passed, with 2,778 pre-existing
+analyzer warnings and zero errors. This is not a claim that the entire AiDotNet test
+suite or all 963 integration cases ran on .NET Framework.
+
+`verification.zip` retains the six exact AiDotNet/core runtime DLLs, three changed
+source files, test receipts, full build logs and the failed development attempts.
+`integrity.json` and the internal manifest bind every artifact to its bytes.
+All three final AiDotNet binaries report product version `0.204.0+d9eb58f46e1f97c3bb300dea0c5e2b70f1321964`.
+The archive is diagnostic evidence, **not a published NuGet package** or a complete
+standalone test installation; dependencies are restored through the source projects.
+
+```powershell
+python docs/evidence/raw-program-samples/d9eb58f/verify.py
+$env:DOTNET_PROCESSOR_COUNT='4'
+$env:DOTNET_gcServer='0'
+$env:DOTNET_GCHeapHardLimit='0x300000000'
+# Check out the pinned sources; substitute your absolute core project path.
+dotnet test tests/AiDotNet.Evolution.Integration.Tests -c Release -f net10.0 -m:1 -p:UseSharedCompilation=false -p:UseLocalEvolution=true -p:EvolutionProjectPath=<core-project> -p:GeneratePackageOnBuild=false
+# Repeat with -f net8.0. Build src/AiDotNet.csproj with -f net471 and the same source-reference properties.
+```
+
+For the legacy subset, place the archived harness at
+`.local/LegacyEvidenceTests/LegacyEvidenceTests.csproj`, then test it with the same
+properties plus `-p:BuildProjectReferences=false` after building the legacy library.
+The initial 4 GiB compiler cap exhausted memory; 12 GiB allowed the full build.
+A source-linked diagnostic initially missed a Newtonsoft.Json runtime dependency,
+and the first full build exposed ambiguous global JSON imports; both failed attempts
+remain alongside their successful corrections. Neither preliminary result is substituted
+for the final source-pinned integration receipts.
+
+This verifies bounded raw scalar evidence retention, candidate/origin/provider binding,
+mean and sample standard error, capacity/atomicity, corruption/freshness/force-fresh
+behavior and current correctness rechecks. It cannot attest honest acquisition,
+statistical independence, stationarity or other descriptors. The matched-prior noisy
+campaign is in [core PR #62](https://github.com/ooples/AiDotNet.Evolution/pull/62).
+Hosted CI, review, dependency integration and normal published-package verification
+remain separate merge/release gates. No competitor or whole-roadmap completion claim.

--- a/docs/evidence/raw-program-samples/d9eb58f/integrity.json
+++ b/docs/evidence/raw-program-samples/d9eb58f/integrity.json
@@ -1,0 +1,6 @@
+{
+  "SourceRevision": "d9eb58f46e1f97c3bb300dea0c5e2b70f1321964",
+  "ArchiveSha256": "f6f5effea71e4b122b721a2e0e306b90666b5ab937922ff034f97787157c00b4",
+  "ArchiveBytes": 40224127,
+  "Entries": 27
+}

--- a/docs/evidence/raw-program-samples/d9eb58f/verify.py
+++ b/docs/evidence/raw-program-samples/d9eb58f/verify.py
@@ -1,0 +1,38 @@
+"""Verify archived receipts and exact runtime/source bytes; no extraction or execution."""
+import hashlib
+import json
+from pathlib import Path, PurePosixPath
+import xml.etree.ElementTree as ET
+import zipfile
+
+root = Path(__file__).resolve().parent
+revision = "d9eb58f46e1f97c3bb300dea0c5e2b70f1321964"
+
+
+def require(condition, message):
+    if not condition:
+        raise ValueError(message)
+
+
+integrity = json.loads((root / "integrity.json").read_bytes())
+source = root / "verification.zip"
+require(integrity["SourceRevision"] == revision and source.stat().st_size == integrity["ArchiveBytes"] < 100 * 1024 * 1024, "Identity/size mismatch.")
+with source.open("rb") as stream:
+    require(hashlib.file_digest(stream, "sha256").hexdigest() == integrity["ArchiveSha256"], "Archive checksum mismatch.")
+with zipfile.ZipFile(source) as archive:
+    names = archive.namelist()
+    require(len(names) == len(set(names)) == integrity["Entries"] < 100, "Duplicate/excessive archive entries.")
+    require(all(not PurePosixPath(name).is_absolute() and ".." not in PurePosixPath(name).parts and "\\" not in name and ":" not in name for name in names), "Unsafe archive path.")
+    require(all(entry.file_size <= 64 * 1024 * 1024 for entry in archive.infolist()) and sum(entry.file_size for entry in archive.infolist()) <= 512 * 1024 * 1024, "Archive exceeds bounds.")
+    manifest = json.loads(archive.read("manifest.json"))
+    require(manifest["SourceRevision"] == revision and manifest["CoreSourceRevision"] == "255feb24369702a32ea9db7a3f8a0b7a847d2762" and
+        set(manifest["Files"]) == set(names) - {"manifest.json"}, "Manifest mismatch.")
+    for name, checksum in manifest["Files"].items():
+        require(hashlib.sha256(archive.read(name)).hexdigest() == checksum, "Artifact checksum mismatch: " + name)
+    for filename, expected in (("all-evolution-pinned-net10.trx", 963), ("all-evolution-net8.trx", 963), ("raw-evidence-net471.trx", 22)):
+        counters = ET.fromstring(archive.read("tests/" + filename)).find(".//{*}Counters")
+        require(counters is not None and all(counters.attrib[key] == str(expected) for key in ("total", "executed", "passed")) and counters.attrib["failed"] == "0", "Test receipt mismatch.")
+    for framework in ("net10.0", "net8.0", "net471"):
+        for filename in ("AiDotNet.dll", "AiDotNet.Evolution.dll"):
+            require(f"runtime/{framework}/{filename}" in manifest["Files"], "Missing tested runtime.")
+print(json.dumps({"Verified": True, "SourceRevision": revision, "ModernIntegrationTestsEach": 963, "LegacyProviderTests": 22}))

--- a/src/Evolution/Programs/DirectoryProgramSampleEvidenceStore.cs
+++ b/src/Evolution/Programs/DirectoryProgramSampleEvidenceStore.cs
@@ -1,0 +1,209 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using AiDotNet.Interfaces;
+using JsonException = System.Text.Json.JsonException;
+using JsonSerializer = System.Text.Json.JsonSerializer;
+
+namespace AiDotNet.Evolution.Programs;
+
+/// <summary>Atomic, content-addressed raw scalar observations for persistent program-fitness reuse.</summary>
+/// <remarks>
+/// Supply genuine observations through the capture callback, not synthetic copies of an aggregate.
+/// Verification reopens the artifact, validates its digest and exact candidate/origin/result binding, and
+/// recomputes mean and sample standard error. Only ProgramMeasurementStatistics.Version is supported;
+/// confidence intervals and other aggregation policies require a different provider. Descriptors/objectives
+/// are bound metadata, not independently measured by scalar samples. Current correctness remains outside reuse.
+/// The private directory must be protected from hostile writers and aliases. Hashes are not signatures or
+/// proof of physical acquisition, independence, hardware identity or stationarity. Cooperating writers use
+/// an exclusive file handle; contention declines persistence through IOException, without retrying forever.
+/// Each artifact is bounded; no eviction, overwrite, external service, evaluator or background task runs here.
+/// The capture callback must be thread-safe, bounded and separately metered; logical facade counters are not I/O costs.
+/// </remarks>
+public sealed class DirectoryProgramSampleEvidenceStore : IProgramMeasurementEvidenceStore
+{
+    /// <summary>Maximum encoded bytes per evidence artifact, including bound metadata.</summary>
+    public const int MaximumArtifactBytes = 2 * 1024 * 1024;
+    private static readonly UTF8Encoding Utf8 = new(false, true);
+    private readonly Func<ProgramGenome, EvolutionTaskResult, EvolutionEvaluationContext, CancellationToken,
+        ValueTask<IReadOnlyList<ProgramMeasurementObservation>?>> _capture;
+    private int _cleanupFailed;
+
+    /// <summary>Creates a private absolute store with an explicit acquisition-source fingerprint and capacity.</summary>
+    public DirectoryProgramSampleEvidenceStore(string directory, string captureVersion,
+        Func<ProgramGenome, EvolutionTaskResult, EvolutionEvaluationContext, CancellationToken,
+            ValueTask<IReadOnlyList<ProgramMeasurementObservation>?>> capture, int maximumEntries = 4096)
+    {
+        if (directory is null) throw new ArgumentNullException(nameof(directory));
+        VersionPinnedProgramFitnessEvaluator.ValidateIdentity(captureVersion, nameof(captureVersion));
+        _capture = capture ?? throw new ArgumentNullException(nameof(capture));
+        if (!Path.IsPathRooted(directory) || (Path.DirectorySeparatorChar == '\\' &&
+            !directory.StartsWith("\\\\", StringComparison.Ordinal) &&
+            (directory.Length < 3 || !char.IsLetter(directory[0]) || directory[1] != ':' || directory[2] is not ('\\' or '/'))))
+            throw new ArgumentException("Use a fully qualified private evidence directory.", nameof(directory));
+        string full = Path.GetFullPath(directory).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        string root = (Path.GetPathRoot(Path.GetFullPath(directory)) ?? string.Empty).TrimEnd(Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar);
+        if (string.Equals(full, root, StringComparison.OrdinalIgnoreCase)) throw new ArgumentException("A filesystem root cannot be an evidence store.", nameof(directory));
+        if (maximumEntries < 1 || maximumEntries > 1_000_000) throw new ArgumentOutOfRangeException(nameof(maximumEntries));
+        DirectoryPath = full; MaximumEntries = maximumEntries;
+        VersionHash = EvolutionHash.Combine(new[] { "directory-program-samples-v1", ProgramMeasurementStatistics.Version, captureVersion });
+        Directory.CreateDirectory(full);
+    }
+
+    /// <inheritdoc/>
+    public string VersionHash { get; }
+    /// <summary>Gets the lexical private root; this is not a symlink or security attestation.</summary>
+    public string DirectoryPath { get; }
+    /// <summary>Gets the cooperating-writer artifact count limit; retained evidence is never evicted.</summary>
+    public int MaximumEntries { get; }
+    /// <summary>Gets whether temporary cleanup failed; the original publication outcome is preserved.</summary>
+    public bool HasTemporaryCleanupFailure => Volatile.Read(ref _cleanupFailed) != 0;
+
+    /// <inheritdoc/>
+    public async ValueTask<string?> RetainAsync(ProgramGenome candidate, EvolutionTaskResult measurement,
+        EvolutionEvaluationContext context, CancellationToken cancellationToken = default)
+    {
+        ValidateArguments(candidate, measurement, context); cancellationToken.ThrowIfCancellationRequested();
+        if (measurement.MeasurementOrigin?.Kind != EvolutionMeasurementOriginKind.Measured) return null;
+        var captured = await _capture(candidate, measurement, context, cancellationToken).ConfigureAwait(false);
+        cancellationToken.ThrowIfCancellationRequested();
+        if (captured is null) return null;
+        var samples = captured.Take(EvolutionMeasurementOrigin.MaximumSampleIds + 1).ToArray();
+        if (!Matches(measurement, samples)) return null;
+        string binding = Binding(candidate, measurement);
+        string json = JsonSerializer.Serialize(new { SchemaVersion = 1, Binding = binding, Observations = samples });
+        if (Utf8.GetByteCount(json) > MaximumArtifactBytes) return null;
+        string digest = EvolutionHash.Compute(json);
+        byte[] bytes = Utf8.GetBytes(json);
+        // The persistent lock marker is not evidence and is never deleted; the OS releases its handle on crash.
+        using var gate = new FileStream(FileName(".writer.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
+        cancellationToken.ThrowIfCancellationRequested();
+        byte[]? existing = Read(digest, cancellationToken);
+        if (existing is not null)
+        {
+            if (!bytes.SequenceEqual(existing)) throw new InvalidDataException("Existing raw evidence conflicts with its digest.");
+            return digest;
+        }
+        if (Directory.EnumerateFiles(DirectoryPath, "*.json", SearchOption.TopDirectoryOnly).Take(MaximumEntries).Count() >= MaximumEntries) return null;
+        string temporary = FileName(".raw-" + Guid.NewGuid().ToString("N") + ".tmp");
+        try
+        {
+            using (var file = new FileStream(temporary, FileMode.CreateNew, FileAccess.Write, FileShare.None))
+            {
+                file.Write(bytes, 0, bytes.Length); file.Flush(true);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            File.Move(temporary, FileName(digest + ".json"));
+            return digest;
+        }
+        finally
+        {
+            try { if (File.Exists(temporary)) File.Delete(temporary); }
+            catch (IOException) { Interlocked.Exchange(ref _cleanupFailed, 1); }
+            catch (UnauthorizedAccessException) { Interlocked.Exchange(ref _cleanupFailed, 1); }
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask<bool> VerifyAsync(ProgramGenome candidate, EvolutionTaskResult measurement, string evidenceSha256,
+        EvolutionEvaluationContext context, CancellationToken cancellationToken = default)
+    {
+        ValidateArguments(candidate, measurement, context); cancellationToken.ThrowIfCancellationRequested();
+        if (evidenceSha256 is null || evidenceSha256.Length != 64 || evidenceSha256.Any(c => c is not (>= '0' and <= '9') and not (>= 'a' and <= 'f')))
+            return new(false);
+        byte[]? bytes = Read(evidenceSha256, cancellationToken);
+        if (bytes is null) return new(false);
+        try
+        {
+            string json = Utf8.GetString(bytes);
+            if (EvolutionHash.Compute(json) != evidenceSha256) return new(false);
+            using var document = JsonDocument.Parse(json, new JsonDocumentOptions { MaxDepth = 8 });
+            var root = document.RootElement;
+            Fields(root, "SchemaVersion", "Binding", "Observations");
+            if (root.GetProperty("SchemaVersion").GetInt32() != 1 || root.GetProperty("Binding").GetString() != Binding(candidate, measurement)) return new(false);
+            var samples = new List<ProgramMeasurementObservation>();
+            foreach (var element in root.GetProperty("Observations").EnumerateArray())
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (samples.Count >= EvolutionMeasurementOrigin.MaximumSampleIds) return new(false);
+                Fields(element, "SampleId", "Value");
+                string? sampleId = element.GetProperty("SampleId").GetString();
+                if (sampleId is null) return new(false);
+                samples.Add(new ProgramMeasurementObservation(sampleId, element.GetProperty("Value").GetDouble()));
+            }
+            return new(Matches(measurement, samples));
+        }
+        catch (Exception error) when (error is JsonException or ArgumentException or InvalidOperationException or FormatException or OverflowException or InvalidDataException)
+        { return new(false); }
+    }
+
+    private static bool Matches(EvolutionTaskResult measurement, IReadOnlyList<ProgramMeasurementObservation> samples)
+    {
+        var origin = measurement.MeasurementOrigin;
+        if (measurement.Status != EvolutionEvaluationStatus.Completed || measurement.Quality is not { } quality || measurement.ConstraintViolations.Any(value => value > 0) ||
+            origin is null || origin.StatisticsVersion != ProgramMeasurementStatistics.Version || !origin.StandardError.HasValue ||
+            origin.ConfidenceLevel.HasValue || samples.Any(sample => sample is null) ||
+            !origin.SampleIds.SequenceEqual(samples.Select(sample => sample.SampleId), StringComparer.Ordinal)) return false;
+        try
+        {
+            var stats = ProgramMeasurementStatistics.Calculate(samples);
+            return Close(quality, stats.Mean) && Close(origin.StandardError.Value, stats.StandardError);
+        }
+        catch (ArgumentException) { return false; }
+    }
+
+    private static bool Close(double left, double right) => Math.Abs(left - right) <= 1e-12 * Math.Max(1, Math.Max(Math.Abs(left), Math.Abs(right)));
+
+    private string Binding(ProgramGenome candidate, EvolutionTaskResult measurement) => JsonSerializer.Serialize(new
+    {
+        Provider = VersionHash,
+        candidate.Id,
+        PayloadSha256 = EvolutionHash.Compute(new ProgramGenomeCodec().Serialize(candidate)),
+        measurement.Status,
+        measurement.Quality,
+        measurement.Direction,
+        Descriptors = measurement.Descriptors.OrderBy(pair => pair.Key, StringComparer.Ordinal).ToArray(),
+        measurement.Objectives,
+        measurement.ConstraintViolations,
+        Metrics = measurement.Metrics.OrderBy(pair => pair.Key, StringComparer.Ordinal).ToArray(),
+        Origin = measurement.MeasurementOrigin?.AsReused(EvolutionMeasurementOriginKind.PersistentReuse).ToJson()
+        // Deliberately exclude current operation cost, diagnostics and artifacts; original cost remains in Origin.
+    });
+
+    private byte[]? Read(string digest, CancellationToken cancellationToken)
+    {
+        try
+        {
+            using var file = new FileStream(FileName(digest + ".json"), FileMode.Open, FileAccess.Read, FileShare.Read | FileShare.Delete);
+            if (file.Length > MaximumArtifactBytes) throw new InvalidDataException("Raw evidence exceeds its byte limit.");
+            using var buffer = new MemoryStream();
+            byte[] chunk = new byte[8192];
+            int count;
+            while ((count = file.Read(chunk, 0, chunk.Length)) > 0)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                if (buffer.Length + count > MaximumArtifactBytes) throw new InvalidDataException("Raw evidence exceeds its byte limit.");
+                buffer.Write(chunk, 0, count);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            return buffer.ToArray();
+        }
+        catch (FileNotFoundException) { return null; }
+    }
+
+    private string FileName(string leaf) => DirectoryPath + Path.DirectorySeparatorChar + leaf; // Only validated digest or generated constant/GUID leaves.
+
+    private static void Fields(JsonElement element, params string[] names)
+    {
+        var remaining = new HashSet<string>(names, StringComparer.Ordinal);
+        foreach (var field in element.EnumerateObject()) if (!remaining.Remove(field.Name)) throw new InvalidDataException("Unknown or duplicate raw evidence field.");
+        if (remaining.Count != 0) throw new InvalidDataException("Missing raw evidence field.");
+    }
+
+    private static void ValidateArguments(ProgramGenome candidate, EvolutionTaskResult measurement, EvolutionEvaluationContext context)
+    {
+        if (candidate is null) throw new ArgumentNullException(nameof(candidate));
+        if (measurement is null) throw new ArgumentNullException(nameof(measurement));
+        if (context is null) throw new ArgumentNullException(nameof(context));
+    }
+}

--- a/src/Evolution/Programs/ProgramMeasurementObservation.cs
+++ b/src/Evolution/Programs/ProgramMeasurementObservation.cs
@@ -1,0 +1,47 @@
+namespace AiDotNet.Evolution.Programs;
+
+/// <summary>One original scalar observation, identified independently of later cache lookups.</summary>
+public sealed class ProgramMeasurementObservation
+{
+    /// <summary>Creates a finite observation; the producer owns truthful acquisition and globally stable identity.</summary>
+    public ProgramMeasurementObservation(string sampleId, double value)
+    {
+        VersionPinnedProgramFitnessEvaluator.ValidateIdentity(sampleId, nameof(sampleId));
+        if (double.IsNaN(value) || double.IsInfinity(value)) throw new ArgumentOutOfRangeException(nameof(value));
+        SampleId = sampleId; Value = value;
+    }
+
+    /// <summary>Gets the original sample identity, not a reuse operation identity.</summary>
+    public string SampleId { get; }
+    /// <summary>Gets the observed scalar fitness in the declared measurement units.</summary>
+    public double Value { get; }
+}
+
+/// <summary>Bounded scalar mean and sample-standard-error calculation shared by acquisition and verification.</summary>
+public static class ProgramMeasurementStatistics
+{
+    /// <summary>Fingerprint of Welford arithmetic mean and sqrt(sample variance / n); no confidence interval is inferred.</summary>
+    public const string Version = "program-scalar-mean-standard-error-v1";
+
+    /// <summary>Requires 2–256 distinct finite observations; rejects unrepresentable intermediate arithmetic.</summary>
+    /// <remarks>The standard error assumes independent samples; this calculation cannot establish independence or stationarity.</remarks>
+    public static (double Mean, double StandardError) Calculate(IEnumerable<ProgramMeasurementObservation> observations)
+    {
+        if (observations is null) throw new ArgumentNullException(nameof(observations));
+        var samples = observations.Take(EvolutionMeasurementOrigin.MaximumSampleIds + 1).ToArray();
+        if (samples.Length < 2 || samples.Length > EvolutionMeasurementOrigin.MaximumSampleIds ||
+            samples.Any(sample => sample is null) || samples.Select(sample => sample.SampleId).Distinct(StringComparer.Ordinal).Count() != samples.Length)
+            throw new ArgumentException("Require 2–256 distinct original observations.", nameof(observations));
+        double mean = 0, squaredDeviations = 0;
+        for (int i = 0; i < samples.Length; i++)
+        {
+            double delta = samples[i].Value - mean;
+            mean += delta / (i + 1);
+            squaredDeviations += delta * (samples[i].Value - mean);
+        }
+        double standardError = Math.Sqrt(squaredDeviations / (samples.Length * (samples.Length - 1)));
+        if (double.IsNaN(mean) || double.IsInfinity(mean) || double.IsNaN(standardError) || double.IsInfinity(standardError))
+            throw new ArgumentException("Observation statistics exceed finite arithmetic.", nameof(observations));
+        return (mean, standardError);
+    }
+}

--- a/tests/AiDotNet.Tests/UnitTests/Evolution/Programs/DirectoryProgramSampleEvidenceStoreTests.cs
+++ b/tests/AiDotNet.Tests/UnitTests/Evolution/Programs/DirectoryProgramSampleEvidenceStoreTests.cs
@@ -1,0 +1,251 @@
+using System.IO;
+using System.Text;
+using System.Text.Json;
+using AiDotNet.ProgramSynthesis.Enums;
+using AiDotNet.Evolution;
+using AiDotNet.Evolution.Programs;
+using AiDotNet.Interfaces;
+using Xunit;
+
+namespace AiDotNetTests.UnitTests.Evolution.Programs;
+
+public sealed class DirectoryProgramSampleEvidenceStoreTests : IDisposable
+{
+    private readonly string _root = Path.Combine(Path.GetTempPath(), "raw-samples-" + Guid.NewGuid().ToString("N"));
+    private static readonly ProgramGenome Genome = new("return 1;", ProgramLanguage.CSharp);
+    private static readonly EvolutionEvaluationContext Context = new(0, 1, 2, 1);
+    private readonly ProgramMeasurementObservation[] _samples = { new("sample-a", 1), new("sample-b", 3), new("sample-c", 5) };
+    private readonly DateTimeOffset _observed = new(2026, 9, 11, 12, 0, 0, TimeSpan.Zero);
+
+    private DirectoryProgramSampleEvidenceStore Store(int capacity = 8) => new(_root, "test-collector-v1",
+        (_, _, _, _) => new ValueTask<IReadOnlyList<ProgramMeasurementObservation>?>(_samples), capacity);
+
+    private EvolutionTaskResult Measurement(double quality = 3, double? error = null, string statistics = ProgramMeasurementStatistics.Version,
+        EvolutionMeasurementOriginKind kind = EvolutionMeasurementOriginKind.Measured, string[]? ids = null, double? lower = null) =>
+        EvolutionTaskResult.Completed(quality, new Dictionary<string, double> { ["size"] = 1 }, costUnits: 3)
+            .WithMeasurementOrigin(new EvolutionMeasurementOrigin(new string('a', 64), "source", "0", ids ?? _samples.Select(s => s.SampleId).ToArray(),
+                _observed, 3, "observations-v1", statistics, kind, error ?? Math.Sqrt(4d / 3), lower, lower.HasValue ? 9 : null, lower.HasValue ? 0.95 : null));
+
+    [Fact]
+    public async Task Reopened_provider_recomputes_raw_statistics_and_preserves_origin()
+    {
+        var original = Measurement();
+        string digest = (await Store().RetainAsync(Genome, original, Context))!;
+        Assert.NotNull(digest);
+        var reused = EvolutionTaskResult.Completed(3, new Dictionary<string, double> { ["size"] = 1 }, costUnits: 0)
+            .WithMeasurementOrigin(original.MeasurementOrigin!.AsReused(EvolutionMeasurementOriginKind.PersistentReuse));
+        var reopened = new DirectoryProgramSampleEvidenceStore(_root, "test-collector-v1", (_, _, _, _) => throw new InvalidOperationException("Verify must not acquire new samples."));
+        Assert.True(await reopened.VerifyAsync(Genome, reused, digest, new EvolutionEvaluationContext(19, 55, 9, 1)));
+        Assert.Equal(3, reused.MeasurementOrigin!.SampleCount);
+        Assert.Equal(original.MeasurementOrigin.StandardError, reused.MeasurementOrigin.StandardError);
+        using var artifact = JsonDocument.Parse(File.ReadAllText(Path.Combine(_root, digest + ".json")));
+        Assert.Equal(new[] { 1d, 3d, 5d }, artifact.RootElement.GetProperty("Observations").EnumerateArray().Select(e => e.GetProperty("Value").GetDouble()));
+        Assert.False(reopened.HasTemporaryCleanupFailure);
+    }
+
+    [Theory]
+    [InlineData("mean")]
+    [InlineData("error")]
+    [InlineData("statistics")]
+    [InlineData("identities")]
+    [InlineData("interval")]
+    [InlineData("reused")]
+    public async Task Unverified_statistics_or_original_identity_cannot_be_retained(string change)
+    {
+        var measurement = change switch
+        {
+            "mean" => Measurement(4),
+            "error" => Measurement(error: 0),
+            "statistics" => Measurement(statistics: "arbitrary-median"),
+            "identities" => Measurement(ids: new[] { "other-a", "sample-b", "sample-c" }),
+            "interval" => Measurement(lower: 0),
+            _ => Measurement(kind: EvolutionMeasurementOriginKind.PersistentReuse)
+        };
+        Assert.Null(await Store().RetainAsync(Genome, measurement, Context));
+        Assert.Empty(Directory.GetFiles(_root, "*.json"));
+    }
+
+    [Fact]
+    public async Task Verification_binds_exact_program_values_origin_and_provider_semantics()
+    {
+        var store = Store(); var original = Measurement();
+        string digest = (await store.RetainAsync(Genome, original, Context))!;
+        Assert.False(await store.VerifyAsync(new ProgramGenome("return 2;", ProgramLanguage.CSharp), original, digest, Context));
+        Assert.False(await store.VerifyAsync(Genome, Measurement(4), digest, Context));
+        Assert.False(await store.VerifyAsync(Genome, Measurement(error: 0), digest, Context));
+        Assert.False(await store.VerifyAsync(Genome, Measurement(ids: new[] { "x", "y", "z" }), digest, Context));
+        var changed = new DirectoryProgramSampleEvidenceStore(_root, "other-collector", (_, _, _, _) => new((IReadOnlyList<ProgramMeasurementObservation>?)null));
+        Assert.False(await changed.VerifyAsync(Genome, original, digest, Context));
+    }
+
+    [Theory]
+    [InlineData("raw-value")]
+    [InlineData("duplicate-field")]
+    [InlineData("unknown-field")]
+    [InlineData("truncated")]
+    [InlineData("invalid-utf8")]
+    public async Task Corrupt_raw_artifacts_fail_even_with_a_new_content_digest(string change)
+    {
+        var store = Store(); var original = Measurement();
+        string digest = (await store.RetainAsync(Genome, original, Context))!;
+        string json = File.ReadAllText(Path.Combine(_root, digest + ".json"));
+        if (change == "invalid-utf8")
+        {
+            File.WriteAllBytes(Path.Combine(_root, digest + ".json"), new byte[] { 255 });
+        }
+        else
+        {
+            json = change switch
+            {
+                "raw-value" => json.Replace("\"Value\":1", "\"Value\":2"),
+                "duplicate-field" => json.Replace("\"SchemaVersion\":1", "\"SchemaVersion\":1,\"SchemaVersion\":1"),
+                "unknown-field" => json.Replace("\"SchemaVersion\":1", "\"SchemaVersion\":1,\"Unknown\":1"),
+                _ => "{"
+            };
+            digest = EvolutionHash.Compute(json);
+            File.WriteAllText(Path.Combine(_root, digest + ".json"), json, new UTF8Encoding(false));
+        }
+        Assert.False(await store.VerifyAsync(Genome, original, digest, Context));
+    }
+
+    [Fact]
+    public async Task Capacity_is_non_evicting_and_identical_artifacts_are_idempotent()
+    {
+        var store = Store(1); var original = Measurement();
+        string digest = (await store.RetainAsync(Genome, original, Context))!;
+        byte[] bytes = File.ReadAllBytes(Path.Combine(_root, digest + ".json"));
+        Assert.Equal(digest, await Store(1).RetainAsync(Genome, original, Context));
+        Assert.Null(await Store(1).RetainAsync(new ProgramGenome("return 2;", ProgramLanguage.CSharp), original, Context));
+        Assert.Equal(bytes, File.ReadAllBytes(Path.Combine(_root, digest + ".json")));
+        Assert.Single(Directory.GetFiles(_root, "*.json"));
+        Assert.Empty(Directory.GetFiles(_root, "*.tmp"));
+    }
+
+    [Fact]
+    public async Task Writer_contention_and_cancellation_do_not_publish_partial_artifacts()
+    {
+        var store = Store();
+        using (var gate = new FileStream(Path.Combine(_root, ".writer.lock"), FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None))
+            await Assert.ThrowsAsync<IOException>(() => store.RetainAsync(Genome, Measurement(), Context).AsTask());
+        using var canceled = new CancellationTokenSource(); canceled.Cancel();
+        await Assert.ThrowsAsync<OperationCanceledException>(() => store.RetainAsync(Genome, Measurement(), Context, canceled.Token).AsTask());
+        Assert.Empty(Directory.GetFiles(_root, "*.json"));
+        Assert.NotNull(await store.RetainAsync(Genome, Measurement(), Context));
+    }
+
+    [Fact]
+    public async Task Missing_traversal_and_oversized_artifacts_are_never_reused()
+    {
+        var store = Store();
+        Assert.False(await store.VerifyAsync(Genome, Measurement(), new string('a', 64), Context));
+        Assert.False(await store.VerifyAsync(Genome, Measurement(), "../outside", Context));
+        string path = Path.Combine(_root, new string('a', 64) + ".json");
+        using (var file = File.Create(path)) file.SetLength(DirectoryProgramSampleEvidenceStore.MaximumArtifactBytes + 1);
+        await Assert.ThrowsAsync<InvalidDataException>(() => store.VerifyAsync(Genome, Measurement(), new string('a', 64), Context).AsTask());
+        Assert.Throws<ArgumentException>(() => new DirectoryProgramSampleEvidenceStore("relative", "v1", (_, _, _, _) => new((IReadOnlyList<ProgramMeasurementObservation>?)null)));
+        Assert.Throws<ArgumentException>(() => new DirectoryProgramSampleEvidenceStore(Path.GetPathRoot(_root)!, "v1", (_, _, _, _) => new((IReadOnlyList<ProgramMeasurementObservation>?)null)));
+    }
+
+    [Fact]
+    public void Statistics_reject_missing_repeated_nonfinite_or_unbounded_observations()
+    {
+        var stats = ProgramMeasurementStatistics.Calculate(_samples);
+        Assert.Equal(3, stats.Mean); Assert.Equal(Math.Sqrt(4d / 3), stats.StandardError);
+        Assert.Throws<ArgumentException>(() => ProgramMeasurementStatistics.Calculate(_samples.Take(1)));
+        Assert.Throws<ArgumentException>(() => ProgramMeasurementStatistics.Calculate(new[] { _samples[0], _samples[0] }));
+        Assert.Throws<ArgumentException>(() => ProgramMeasurementStatistics.Calculate(Enumerable.Range(0, 257).Select(i => new ProgramMeasurementObservation("s" + i, i))));
+        Assert.Throws<ArgumentException>(() => ProgramMeasurementStatistics.Calculate(new[] { new ProgramMeasurementObservation("a", double.MaxValue), new ProgramMeasurementObservation("b", -double.MaxValue) }));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgramMeasurementObservation("a", double.NaN));
+        Assert.Throws<ArgumentOutOfRangeException>(() => new ProgramMeasurementObservation("a", double.PositiveInfinity));
+    }
+
+    [Theory]
+    [InlineData("warm")]
+    [InlineData("force-fresh")]
+    [InlineData("expired")]
+    [InlineData("corrupt")]
+    [InlineData("missing")]
+    public async Task Real_directory_cache_and_raw_provider_preserve_freshness_and_current_correctness(string phase)
+    {
+        var backend = new SampleBackend(_observed);
+        int correctnessCalls = 0;
+        var correctness = new DelegateProgramFitnessEvaluator((_, _, _) =>
+        {
+            correctnessCalls++;
+            return new(new EvolutionTaskResult(EvolutionEvaluationStatus.Completed, 1, costUnits: 2));
+        });
+        var ledgers = new List<EvolutionResourceLedger>();
+        async Task<EvolutionTaskResult> Evaluate(string run, bool forceFresh = false)
+        {
+            var ledger = new EvolutionResourceLedger(run, new EvolutionResources(new Dictionary<string, decimal>
+            {
+                [EvolutionPersistentEvaluationCache.StoreInvocationResource] = 4,
+                [PersistentProgramFitnessEvaluator.EvidenceInvocationResource] = 4
+            }));
+            ledgers.Add(ledger);
+            var evidence = new DirectoryProgramSampleEvidenceStore(Path.Combine(_root, "raw"), "authored-samples-v1",
+                (_, _, _, _) => new ValueTask<IReadOnlyList<ProgramMeasurementObservation>?>(backend.Samples));
+            var cached = new PersistentProgramFitnessEvaluator(backend, new DirectoryEvolutionEvaluationStore(Path.Combine(_root, "cache")),
+                evidence, backend.Scope, new EvolutionEvaluationReusePolicy(EvolutionEvaluationReuseMode.ExistingSamples, TimeSpan.FromHours(1), 3),
+                ledger, "three-observations-v1", run, forceFresh, () => backend.Now);
+            return await new CorrectnessGatedProgramFitnessEvaluator(correctness, cached).EvaluateAsync(Genome, Context);
+        }
+        var cold = await Evaluate("cold");
+        if (phase == "expired") backend.Now += TimeSpan.FromHours(2);
+        if (phase is "corrupt" or "missing")
+        {
+            string file = Assert.Single(Directory.GetFiles(Path.Combine(_root, "raw"), "*.json"));
+            if (phase == "corrupt") File.WriteAllText(file, "{}");
+            else File.Delete(file); // Exact artifact in this test's private directory only.
+        }
+        var result = await Evaluate("next", phase == "force-fresh");
+        bool reused = phase == "warm";
+        Assert.Equal(2, correctnessCalls);
+        Assert.Equal(reused ? 1 : 2, backend.Calls);
+        Assert.Equal(5, cold.CostUnits); Assert.Equal(reused ? 2 : 5, result.CostUnits);
+        Assert.Equal(reused ? EvolutionMeasurementOriginKind.PersistentReuse : EvolutionMeasurementOriginKind.Measured, result.MeasurementOrigin!.Kind);
+        Assert.Equal(3, result.MeasurementOrigin.SampleCount);
+        Assert.Equal(3, result.MeasurementOrigin.OriginalCostUnits);
+        Assert.Equal(cold.MeasurementOrigin!.StandardError, result.MeasurementOrigin.StandardError);
+        Assert.Equal(reused, cold.MeasurementOrigin.SampleSetHash == result.MeasurementOrigin.SampleSetHash);
+        Assert.All(ledgers, ledger => Assert.Equal(0, ledger.Snapshot().Unknown));
+        if (reused)
+        {
+            Assert.Equal(cold.MeasurementOrigin.ObservedAt, result.MeasurementOrigin.ObservedAt);
+            Assert.Equal(3m, ledgers.Sum(ledger => ledger.Snapshot().Spent[EvolutionPersistentEvaluationCache.StoreInvocationResource]));
+            Assert.Equal(2m, ledgers.Sum(ledger => ledger.Snapshot().Spent[PersistentProgramFitnessEvaluator.EvidenceInvocationResource]));
+        }
+    }
+
+    private sealed class SampleBackend : IProgramFitnessEvaluator
+    {
+        internal SampleBackend(DateTimeOffset now)
+        {
+            Now = now;
+            var codec = new ProgramGenomeCodec();
+            Scope = new EvolutionReuseScope(Id, VersionHash, VersionHash, codec.Id, codec.VersionHash, "constraints-v1", "authored-data-v1",
+                "three-samples-v1", "compiler-na-v1", "runtime-na-v1", "hardware-na-v1", "current-correctness-v1");
+        }
+        public string Id => "raw-sample-fixture";
+        public string VersionHash => "v1";
+        internal EvolutionReuseScope Scope { get; }
+        internal DateTimeOffset Now { get; set; }
+        internal int Calls { get; private set; }
+        internal IReadOnlyList<ProgramMeasurementObservation> Samples { get; private set; } = Array.Empty<ProgramMeasurementObservation>();
+        public ValueTask<EvolutionTaskResult> EvaluateAsync(ProgramGenome candidate, EvolutionEvaluationContext context, CancellationToken cancellationToken = default)
+        {
+            cancellationToken.ThrowIfCancellationRequested(); Calls++;
+            Samples = Enumerable.Range(0, 3).Select(index => new ProgramMeasurementObservation($"acquisition-{Calls}-{index}", 1 + 2 * index)).ToArray();
+            var statistics = ProgramMeasurementStatistics.Calculate(Samples);
+            return new(EvolutionTaskResult.Completed(statistics.Mean, new Dictionary<string, double>(), costUnits: 3).WithMeasurementOrigin(new EvolutionMeasurementOrigin(
+                Scope.StableKey, "acquisition-" + Calls, context.EvaluationId.ToString(), Samples.Select(sample => sample.SampleId), Now,
+                3, "observations-v1", ProgramMeasurementStatistics.Version, standardError: statistics.StandardError)));
+        }
+    }
+
+    public void Dispose()
+    {
+        // Only this test's generated private child, never a shared directory.
+        if (Directory.Exists(_root)) Directory.Delete(_root, recursive: true);
+    }
+}


### PR DESCRIPTION
## US-23 companion — verified raw scalar measurements for fitness reuse

Refs ooples/AiDotNet.Evolution#41 and core PR ooples/AiDotNet.Evolution#62. Depends on shared AiDotNet foundation #2148; this is a separate companion implementation PR, not a replacement foundation.

Adds `DirectoryProgramSampleEvidenceStore`, `ProgramMeasurementObservation` and `ProgramMeasurementStatistics` to the existing persistent fitness facade. The provider retains original scalar observations, binds exact program/result/origin/provider semantics, recomputes mean and sample standard error, and rejects corrupt, ambiguous, oversized or incompatible evidence. Reuse preserves original sample IDs, uncertainty, observation time and acquisition cost; current correctness checks still run.

Storage is bounded, atomic and non-evicting, with an exclusive cooperating-writer handle. It never executes program text or acquires samples during reuse. Raw scalar samples do not independently validate other descriptors/metrics or prove honest acquisition, independence, stationarity or hardware identity. Other statistics/interval policies need an explicit provider. See [usage and boundaries](https://github.com/ooples/AiDotNet/blob/feat/evolution-us-23/docs/PROGRAM_SAMPLE_EVIDENCE.md).

Verified implementation `d9eb58f46e1f97c3bb300dea0c5e2b70f1321964`: **963/963 evolution integration tests on each of .NET 10 and .NET 8**, no skips, including **22 new raw-evidence cases**. The actual .NET Framework 4.7.1 library also built and passed the **22/22 provider cases**; this is not a claim that all 963 cases ran on legacy. Real on-disk cache/provider tests cover cold/warm reuse, force-fresh, expiration, missing/corrupt evidence and current correctness.

[Offline-verifiable evidence](https://github.com/ooples/AiDotNet/blob/feat/evolution-us-23/docs/evidence/raw-program-samples/d9eb58f/README.md) retains test receipts, exact three-target AiDotNet/core DLLs, source snapshots and failed development attempts. Archive SHA-256: `f6f5effea71e4b122b721a2e0e306b90666b5ab937922ff034f97787157c00b4`; 40,224,127 bytes, 27 entries. The offline verifier passed. Source-linked diagnostics are not substituted for final monolith integration tests. Core PR #62's full campaign passed 1,152 runs and 358,400 physical observations with matching replay; its evidence is tracked there.

**Ready for review of this bounded companion implementation.** Hosted CI/review, shared-foundation/dependency integration and normal published-package integration remain merge/release gates. Local tests use explicit published US-10 source `255feb24369702a32ea9db7a3f8a0b7a847d2762`; roadmap APIs are not yet released in NuGet. No package publication, merge, issue closure, competitor-superiority claim or whole-roadmap completion is implied.
