### PR TITLE
fix: repair the tests that had never actually run

### DIFF
--- a/src/ActiveLearning/RandomSampling.cs
+++ b/src/ActiveLearning/RandomSampling.cs
@@ -39,6 +39,17 @@ public class RandomSampling<T> : IActiveLearningStrategy<T>
 {
     private readonly INumericOperations<T> _numOps;
     private readonly Random _random;
+
+    /// <summary>
+    /// Mixed into every sample's score hash, so the seed actually selects the random draw.
+    /// </summary>
+    /// <remarks>
+    /// Scores are hashed from the pool data so one instance always ranks a pool the same way (the
+    /// k=1 pick is always inside the k=5 picks). Without a salt that hash ignored the seed entirely:
+    /// every RandomSampling, whatever its seed, selected the identical samples, so "random" sampling
+    /// was a fixed ordering of the data and a caller's seed had no effect.
+    /// </remarks>
+    private readonly uint _salt;
     private bool _useBatchDiversity;
     private T _lastMinScore;
     private T _lastMaxScore;
@@ -52,6 +63,7 @@ public class RandomSampling<T> : IActiveLearningStrategy<T>
     {
         _numOps = MathHelper.GetNumericOperations<T>();
         _random = seed.HasValue ? RandomHelper.CreateSeededRandom(seed.Value) : RandomHelper.CreateSecureRandom();
+        _salt = unchecked((uint)_random.Next() ^ ((uint)_random.Next() << 16));
         _useBatchDiversity = false;
         _lastMinScore = _numOps.Zero;
         _lastMaxScore = _numOps.Zero;
@@ -116,8 +128,10 @@ public class RandomSampling<T> : IActiveLearningStrategy<T>
         // The randomness comes from hashing each sample's data values.
         for (int i = 0; i < numSamples; i++)
         {
-            // Hash the sample's features to produce a deterministic pseudo-random score
-            uint hash = (uint)(i * 2654435761L); // Knuth multiplicative hash seed
+            // Hash the sample's features, salted by this instance's seed, to produce a deterministic
+            // pseudo-random score. The salt is what makes two seeds rank the pool differently.
+            uint hash = unchecked((uint)(i * 2654435761L) ^ _salt); // Knuth multiplicative hash seed
+            hash = unchecked((uint)(hash * 2654435761L));
             int featureDim = unlabeledPool.Length / numSamples;
             for (int f = 0; f < Math.Min(featureDim, 8); f++)
             {

--- a/src/NeuralNetworks/NeuralNetworkBase.cs
+++ b/src/NeuralNetworks/NeuralNetworkBase.cs
@@ -2833,19 +2833,17 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
         // model class's forward BEFORE the input hits Layers[0] — e.g. NeRF's positional
         // encoding turns [N, 3] positions into [N, 60] before Layers[0] sees them, and
         // Layers[0] only resolves its DenseLayer input width on that real forward. Drive
-        // one full forward now (SetTrainingMode(false) so batchnorm/dropout stay inference)
-        // to trigger those inside-forward resolutions. The output is discarded; only the
-        // side-effect of materializing lazy layer shapes matters here.
-        bool previousTrainingMode = IsTrainingMode;
-        try
-        {
-            SetTrainingMode(false);
-            _ = ForwardWithMemory(sampleInput);
-        }
-        finally
-        {
-            SetTrainingMode(previousTrainingMode);
-        }
+        // one full forward now to trigger those inside-forward resolutions. The output is
+        // discarded; only the side-effect of materializing lazy layer shapes matters here.
+        //
+        // The forward has to be the model's own inference entry point, not the bare layer loop.
+        // A model may reshape its input before Layers[0] in PredictCore rather than in
+        // ForwardWithMemory: MusicSourceSeparator turns a [B, samples] waveform into the
+        // [B, 1, samples] its first Conv1D needs there, so feeding the caller's sample straight to
+        // the layers threw "Conv1DLayer requires rank-3 input" - from the very method the
+        // SetParameters error tells a user to call. Predict also owns the eval-mode transition
+        // (and restores the prior mode), so batchnorm/dropout stay in inference here.
+        _ = Predict(sampleInput);
     }
 
     /// <summary>
@@ -2907,6 +2905,13 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// Monotonically increasing version counter, incremented when layers are added/removed.
     /// Used by TapeTrainingStep caching to detect structural changes.
     /// </summary>
+    /// <remarks>
+    /// Scratch, not model state: it is a cache key for THIS instance's layer list, meaningless on any
+    /// other. Persisted by default, it made every copy differ from its original, because restoring a
+    /// model rebuilds its layer list and so advances its own counter - a clone's bytes could never
+    /// match the model it was cloned from.
+    /// </remarks>
+    [AiDotNet.Attributes.Scratch]
     private int _layerStructureVersion;
 
     /// <summary>
@@ -5319,11 +5324,21 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// the very thing in question and assuming it is what went wrong last time. Reporting only; the
     /// propagated value is still whichever one <see cref="TryAdvanceLayerShape"/> already chose.
     /// </para>
+    /// <para>
+    /// Scratch, not model state: these are per-instance report counters. Persisted, they made a clone
+    /// serialize differently from its source, because the clone re-walks its shapes and records its
+    /// own tallies.
+    /// </para>
     /// </remarks>
+    [AiDotNet.Attributes.Scratch]
     private int _propagationShadowAgreedBatched;
+    [AiDotNet.Attributes.Scratch]
     private int _propagationShadowAgreedPerSample;
+    [AiDotNet.Attributes.Scratch]
     private int _propagationShadowDeclined;
+    [AiDotNet.Attributes.Scratch]
     private int _propagationShadowDisagreedBoth;
+    [AiDotNet.Attributes.Scratch]
     private List<string>? _propagationShadowDisagreements;
     /// <summary>
     /// Whether lazy shape resolution has already run on this instance.
@@ -12054,6 +12069,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// follows. Reset at the top of every <see cref="TrainWithTape"/>
     /// call so a prior step's bail-out can't leak into this one.
     /// </summary>
+    [AiDotNet.Attributes.Scratch]
     private string? _pendingFusedMissReason;
 
     /// <summary>
@@ -12072,6 +12088,7 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// after the first warning. <see cref="Configuration.TrainingDiagnosticsConfig"/>
     /// at PerStep still gives per-step detail for those who want it.
     /// </summary>
+    [AiDotNet.Attributes.Scratch]
     private bool _loggedFusedFallback;
 
     /// <summary>
@@ -15361,6 +15378,24 @@ public abstract partial class NeuralNetworkBase<T> : INeuralNetworkModel<T>, IIn
     /// </summary>
 
     public virtual IFullModel<T, Tensor<T>, Tensor<T>> DeepCopy()
+    {
+        // A copy is state-identical to its source, INCLUDING its training mode. Every path below
+        // restores through the layer deserializer, which deliberately leaves a restored model in
+        // inference mode (right for a model loaded from bytes, wrong for a clone). Before training
+        // mode became serialized state (#1789) that difference was invisible; after it, a training
+        // network's copy serialized to different bytes than its original, and a clone taken mid-
+        // training silently switched dropout and batch statistics off. Deserialize itself is
+        // unchanged: loading a model still starts it in inference mode.
+        var copy = DeepCopyRestoredInInferenceMode();
+        if (copy is NeuralNetworkBase<T> network && network.IsTrainingMode != IsTrainingMode)
+        {
+            network.SetTrainingMode(IsTrainingMode);
+        }
+
+        return copy;
+    }
+
+    private IFullModel<T, Tensor<T>, Tensor<T>> DeepCopyRestoredInInferenceMode()
     {
 
         // G6 COW fast path: share weight-tensor storage instead of materializing a second full copy.

--- a/src/TextToSpeech/CodecBased/BarkModel.cs
+++ b/src/TextToSpeech/CodecBased/BarkModel.cs
@@ -639,21 +639,28 @@ public partial class BarkModel<T> : TtsModelBase<T>
 
 
     /// <summary>
-    /// Recreates the injected codec dependency for cloning while leaving Bark parameter transfer to
-    /// the framework's single generated layer manifest.
+    /// The codec this model was constructed with, as the clone plan's source for the constructor's
+    /// <c>codec</c> argument.
     /// </summary>
-    protected IAudioCodec<T> CreateCodecForNewInstance()
-    {
-        if (_codec.Codec is IFullModel<T, Tensor<T>, Tensor<T>> model
-            && model.Clone() is IAudioCodec<T> clonedCodec)
-        {
-            return clonedCodec;
-        }
-
-        // Stateless/custom codecs do not expose a clone contract. Sharing that external service is
-        // safe; all Bark-owned trainable state still lives in the generated layer graph.
-        return _codec.Codec;
-    }
+    /// <remarks>
+    /// <para>
+    /// The injected codec is stored only inside <see cref="_codec"/>, whose type is the wrapping
+    /// layer, so nothing on the model could supply the constructor's <c>codec</c> parameter. The
+    /// generated plan therefore passed its default, null, and every clone was rebuilt around a fresh
+    /// default EnCodec: a model built with its own codec was cloned with a different, untrained one,
+    /// and the clone reported that codec's parameters on top of the original's (29,026 against
+    /// 28,337 for the tiny test configuration). A hand-written <c>CreateCodecForNewInstance</c> meant
+    /// to prevent this was never called by anything.
+    /// </para>
+    /// <para>
+    /// Exposing the codec here lets the plan find it by name, and <c>CloneEngine</c> already applies
+    /// the policy that method described: a codec with a clone contract is cloned, a stateless one is
+    /// shared. The member is an alias of <see cref="_codec"/>, which remains the only owner of the
+    /// codec's parameters, so nothing is counted or restored twice.
+    /// </para>
+    /// </remarks>
+    [ParameterAlias(nameof(_codec))]
+    private IAudioCodec<T> Codec => _codec.Codec;
 
     private void TrainStage(
         TrainingStage stage,

--- a/src/Video/ActionRecognition/VideoMAE.cs
+++ b/src/Video/ActionRecognition/VideoMAE.cs
@@ -47,11 +47,12 @@ namespace AiDotNet.Video.ActionRecognition;
 /// // Create a VideoMAE model for action recognition on Kinetics-400
 /// var videoMAE = new VideoMAE&lt;double&gt;();
 ///
-/// // Or configure with a custom architecture and parameters
+/// // Or configure with a custom architecture and parameters. Declare the input as
+/// // FourDimensional [frames, channels, height, width] so GetInputShape() describes a clip.
 /// var architecture = new NeuralNetworkArchitecture&lt;double&gt;(
-///     inputType: InputType.ThreeDimensional,
+///     inputType: InputType.FourDimensional,
 ///     taskType: NeuralNetworkTaskType.MultiClassClassification,
-///     inputHeight: 224, inputWidth: 224, inputDepth: 3,
+///     inputFrames: 16, inputHeight: 224, inputWidth: 224, inputDepth: 3,
 ///     outputSize: 400);
 /// var model = new VideoMAE&lt;double&gt;(architecture, numClasses: 400, numFrames: 16);
 /// </code>
@@ -142,13 +143,27 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
     #region Constructors
 
     /// <summary>
-    /// Initializes a new instance of VideoMAE with default architecture (224x224, 400 classes).
+    /// Initializes a new instance of VideoMAE with default architecture (16 frames of 224x224, 400 classes).
     /// </summary>
+    /// <remarks>
+    /// The default architecture is declared <see cref="Enums.InputType.FourDimensional"/>
+    /// ([frames, channels, height, width]) with 16 frames, in lockstep with the
+    /// <c>numFrames = 16</c> default of the native constructor. It used to be declared
+    /// <see cref="Enums.InputType.ThreeDimensional"/>, whose <c>GetInputShape()</c> is
+    /// [channels, height, width] = [3, 224, 224]: a SINGLE frame. VideoMAE reads a rank-4
+    /// input as an unbatched clip [T, C, H, W] (see the TensorLayout attribute), so that
+    /// declared shape was consumed as a 1-frame clip, and <see cref="PatchEmbed"/> folds
+    /// frames in tubelets of 2 — 1 / 2 = 0 tubelets, an empty [0, 6, 224, 224] batch for
+    /// the tubelet convolution. A model's declared input shape must be an input it
+    /// accepts; any caller that builds its probe from the architecture (serving, the
+    /// shape-discovery and traced-chain sweeps, a user following <c>GetInputShape()</c>)
+    /// hit that on the first Predict.
+    /// </remarks>
     public VideoMAE()
         : this(new NeuralNetworkArchitecture<T>(
-            inputType: Enums.InputType.ThreeDimensional,
+            inputType: Enums.InputType.FourDimensional,
             taskType: Enums.NeuralNetworkTaskType.MultiClassClassification,
-            inputHeight: 224, inputWidth: 224, inputDepth: 3,
+            inputFrames: 16, inputHeight: 224, inputWidth: 224, inputDepth: 3,
             outputSize: 400)) { }
 
     /// <summary>
@@ -544,6 +559,23 @@ public partial class VideoMAE<T> : NeuralNetworkBase<T>
         int channels = video.Shape[2];
         int height = video.Shape[3];
         int width = video.Shape[4];
+
+        // A clip shorter than one tubelet has NO tubelets: numFrames / _tubeletSize is 0, the
+        // tubelet batch below would be [0, channels * _tubeletSize, H, W], and the empty tensor
+        // reached the engine's bias broadcast inside Layers[0] as an opaque
+        // "Inner left-operand block exceeds its span" instead of a statement of what is wrong
+        // with the input. The reference (a Conv3d with temporal kernel = stride = tubelet size)
+        // rejects such a clip too, so reject it here, in terms of the input, before the conv.
+        // Trailing frames beyond a whole tubelet are dropped, exactly as that strided Conv3d
+        // drops them, so only the too-short case is an error.
+        if (numFrames < _tubeletSize)
+        {
+            throw new ArgumentException(
+                $"VideoMAE embeds frames in tubelets of {_tubeletSize}, so a clip needs at least "
+                + $"{_tubeletSize} frames; got {numFrames}. Input layout is [T, C, H, W] or "
+                + $"[B, T, C, H, W] (received shape [{string.Join(", ", video._shape)}]).",
+                nameof(video));
+        }
 
         // Combine frames into tubelet pairs
         int numTubelets = numFrames / _tubeletSize;

--- a/tests/AiDotNet.Tests/IntegrationTests/ActiveLearning/ActiveLearningIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/ActiveLearning/ActiveLearningIntegrationTests.cs
@@ -361,10 +361,13 @@ public class ActiveLearningIntegrationTests
         var strategy2 = new RandomSampling<double>(seed: 123);
         var selected2 = strategy2.SelectSamples(model, pool, 10);
 
-        // Assert - Different seeds should (very likely) produce different selections
+        // Assert - Different seeds must produce different selections. Both seeds are fixed, so this
+        // is deterministic, not a probabilistic "very likely": until the seed was mixed into the
+        // score hash every seed selected the identical ten samples, and this test (which then only
+        // checked the lengths) could not tell.
         Assert.Equal(10, selected1.Length);
         Assert.Equal(10, selected2.Length);
-        // Note: There's a tiny chance they could be equal, but extremely unlikely with 100 samples
+        Assert.NotEqual(selected1, selected2);
     }
 
     [Fact(Timeout = 120000)]
@@ -385,24 +388,33 @@ public class ActiveLearningIntegrationTests
         Assert.Equal(selected1, selected2);
     }
 
+    /// <summary>
+    /// Random sampling scores are pseudo-random draws in [0, 1], stable for one seed and pool.
+    /// </summary>
+    /// <remarks>
+    /// This test used to assert that every score was EQUAL. RandomSampling deliberately stopped doing
+    /// that: with equal scores the top-k order is arbitrary, so a k=1 selection was not guaranteed to
+    /// be inside the k=5 selection. It never ran in CI (no shard filter selected this class), so the
+    /// stale assertion went unnoticed.
+    /// </remarks>
     [Fact(Timeout = 120000)]
-    public async Task RandomSampling_InformativenessScores_AreUniform()
+    public async Task RandomSampling_InformativenessScores_AreStableDrawsInTheUnitInterval()
     {
-        // Random sampling should assign uniform scores (all equal)
-        var strategy = new RandomSampling<double>();
         var model = CreateMockModel(3);
         var pool = CreateUnlabeledPool(20, 5);
 
-        // Act
-        var scores = strategy.ComputeInformativenessScores(model, pool);
+        var scores = new RandomSampling<double>(seed: 7).ComputeInformativenessScores(model, pool);
+        var sameSeed = new RandomSampling<double>(seed: 7).ComputeInformativenessScores(model, pool);
+        var otherSeed = new RandomSampling<double>(seed: 8).ComputeInformativenessScores(model, pool);
 
-        // Assert - All scores should be the same (or very close due to implementation)
-        var firstScore = scores[0];
-        // Random sampling typically assigns equal informativeness
-        foreach (var score in scores)
+        Assert.Equal(pool.Shape[0], scores.Length);
+        for (int i = 0; i < scores.Length; i++)
         {
-            Assert.Equal(firstScore, score, 1e-10);
+            Assert.InRange(scores[i], 0.0, 1.0);
+            Assert.Equal(scores[i], sameSeed[i]);
         }
+        Assert.True(scores.Distinct().Count() > 1, "random sampling produced a constant score");
+        Assert.NotEqual(scores.ToArray(), otherSeed.ToArray());
     }
 
     #endregion

--- a/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/PrivBayesDifferentialPrivacyTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/SyntheticData/PrivBayesDifferentialPrivacyTests.cs
@@ -387,14 +387,34 @@ public class PrivBayesDifferentialPrivacyTests
     }
 
     /// <summary>
-    /// A budget entirely allocated to one phase must not break the other. At fraction 1.0 the marginal
-    /// phase gets zero budget, and at 0.0 the structure phase does; both must degrade gracefully
-    /// instead of dividing by zero.
+    /// A budget split that starves either phase is REJECTED, not degraded. At 1.0 the conditional
+    /// distributions would be published with no privacy noise while differential privacy still
+    /// reported as enabled; at 0.0 the structure would be learned non-privately. Both look like
+    /// working configurations, which is why BayesianNetworkSynthOptions refuses them outright.
     /// </summary>
+    /// <remarks>
+    /// This test originally asserted the opposite (graceful degradation at the endpoints). It never
+    /// ran in CI - no shard filter selected this class - so it went stale when the option began
+    /// validating its range. The graceful-degradation intent is kept at the extremes that remain
+    /// legal, below.
+    /// </remarks>
     [Theory]
     [InlineData(0.0)]
     [InlineData(1.0)]
-    public void DegenerateBudgetSplit_DoesNotProduceNaN(double fraction)
+    public void DegenerateBudgetSplit_IsRejected(double fraction)
+    {
+        var options = new BayesianNetworkSynthOptions<double>();
+        Assert.Throws<ArgumentOutOfRangeException>(() => options.StructureBudgetFraction = fraction);
+    }
+
+    /// <summary>
+    /// The most lopsided splits that ARE allowed must still leave both phases a usable budget:
+    /// no division by zero, no NaN in the synthetic output.
+    /// </summary>
+    [Theory]
+    [InlineData(0.001)]
+    [InlineData(0.999)]
+    public void ExtremeLegalBudgetSplit_DoesNotProduceNaN(double fraction)
     {
         var m = FitAndGenerate(new BayesianNetworkSynthOptions<double>
         {

--- a/tests/AiDotNet.Tests/IntegrationTests/Training/TrainingRecipeIntegrationTests.cs
+++ b/tests/AiDotNet.Tests/IntegrationTests/Training/TrainingRecipeIntegrationTests.cs
@@ -221,13 +221,16 @@ namespace AiDotNetTests.IntegrationTests.Training
             Assert.IsAssignableFrom<ITimeSeriesModel<double>>(model);
             Assert.NotNull(model.DefaultLossFunction);
 
-            // Act - train and predict
+            // Act - train and predict. The two series must not be collinear: VAR regresses each on the
+            // lags of both, and with series[1] = 0.5 * series[0] (this test's original data) the lag
+            // columns are linearly dependent, X'X is singular, and OLS is genuinely unidentified - the
+            // model correctly refuses with a zero-pivot error rather than inventing coefficients.
             var features = new Matrix<double>(50, 2);
             var labels = new Vector<double>(50);
             for (int i = 0; i < 50; i++)
             {
-                features[i, 0] = i;
-                features[i, 1] = i * 0.5;
+                features[i, 0] = Math.Sin(i * 0.3) + i * 0.05;
+                features[i, 1] = Math.Cos(i * 0.17) - i * 0.02;
                 labels[i] = i * 2.0;
             }
             model.Train(features, labels);

--- a/tests/AiDotNet.Tests/MssCloneVsSerializeLocalization.cs
+++ b/tests/AiDotNet.Tests/MssCloneVsSerializeLocalization.cs
@@ -9,56 +9,81 @@ using Xunit.Abstractions;
 namespace AiDotNet.Tests;
 
 /// <summary>
-/// Splits MusicSourceSeparator's clone divergence between Clone()'s copy-on-write fast path and the
-/// serialize/deserialize path they are both supposed to agree with.
+/// MusicSourceSeparator's Clone(), a serialize/deserialize round-trip, and a bare parameter copy must
+/// all reproduce the original model's predictions.
 /// </summary>
 /// <remarks>
-/// Established already: the clone's parameters are bit-identical (0/5892), it takes the same Demucs
-/// forward path (identical activation keys), Predict is deterministic on one instance, and Encoder_0 —
-/// the FIRST layer — already differs by 7.93e-01. NeuralNetworkBase.DeepCopy has a COW branch that
-/// returns early before the serialize path runs, so if an explicit round-trip MATCHES while Clone does
-/// not, the defect is in that branch rather than in any layer's restore.
+/// <para>
+/// This began as a localization scaffold for a clone divergence (the clone's parameters were
+/// bit-identical, yet Encoder_0's output differed by 7.93e-01) and asserted nothing. It also never
+/// ran in CI: no shard filter selected this class, so when the paper-default configuration began
+/// requiring at least 4096 samples, its 64-sample input went stale without anyone noticing.
+/// </para>
+/// <para>
+/// It now asserts what the scaffold was measuring, so a regression in any of the three copy paths
+/// fails instead of printing a number nobody reads.
+/// </para>
 /// </remarks>
 public class MssCloneVsSerializeLocalization
 {
+    private const int Samples = 64;
+    private const double Tolerance = 1e-9;
+
     private readonly ITestOutputHelper _out;
     public MssCloneVsSerializeLocalization(ITestOutputHelper o) => _out = o;
 
+    // The same smoke-scale Demucs the generated ModelFamily scaffold uses (TestScaffoldGenerator):
+    // the paper defaults build a 100.6M-parameter double fixture that needs >= 4096 samples, peaks at
+    // several GiB, and would hold four of them here.
+    private static MusicSourceSeparator<double> Create(NeuralNetworkArchitecture<double> arch) =>
+        new(arch, new SourceSeparationOptions
+        {
+            DemucsDepth = 2, DemucsBaseChannels = 8, DemucsKernelSize = 8,
+            DemucsStride = 4, DemucsPadding = 2, StemCount = 4,
+        });
+
     [Fact]
-    public void Localize()
+    public void CloneSerializeAndParameterCopy_ReproduceTheOriginalPrediction()
     {
         var arch = new NeuralNetworkArchitecture<double>(
             inputType: InputType.OneDimensional,
             taskType: NeuralNetworkTaskType.Regression,
-            inputSize: 64, outputSize: 64);
-        using var model = new MusicSourceSeparator<double>(arch);
+            inputSize: Samples, outputSize: 256);
+        using var model = Create(arch);
 
         var rng = new Random(7);
-        var input = new Tensor<double>([1, 64]);
+        var input = new Tensor<double>([1, Samples]);
         for (int i = 0; i < input.Length; i++) input[i] = rng.NextDouble() * 2 - 1;
 
         var baseline = model.Predict(input);
 
         static double Worst(Tensor<double> a, Tensor<double> b)
         {
+            Assert.Equal(a.Length, b.Length);
             double w = 0;
-            for (int i = 0; i < Math.Min(a.Length, b.Length); i++) w = Math.Max(w, Math.Abs(a[i] - b[i]));
+            for (int i = 0; i < a.Length; i++) w = Math.Max(w, Math.Abs(a[i] - b[i]));
             return w;
         }
 
-        var cloned = (MusicSourceSeparator<double>)model.Clone();
-        _out.WriteLine($"CLONE            worstDelta={Worst(baseline, cloned.Predict(input)):E3}");
+        using var cloned = (MusicSourceSeparator<double>)model.Clone();
+        double cloneDelta = Worst(baseline, cloned.Predict(input));
 
         byte[] bytes = model.Serialize();
-        using var restored = new MusicSourceSeparator<double>(arch);
+        using var restored = Create(arch);
         restored.Deserialize(bytes);
-        _out.WriteLine($"SERIALIZE/DESER  worstDelta={Worst(baseline, restored.Predict(input)):E3}");
+        double serializeDelta = Worst(baseline, restored.Predict(input));
 
-        // A fresh instance handed the original's parameter vector directly — no serialization at all.
-        using var viaParams = new MusicSourceSeparator<double>(arch);
+        // A fresh instance handed the original's parameter vector directly - no serialization at all.
+        // Its lazy layers have no shapes until they see an input, so they are resolved first, exactly
+        // as the SetParameters error directs for a fresh model receiving trained weights.
+        using var viaParams = Create(arch);
+        viaParams.ResolveShapes(input);
         viaParams.UpdateParameters(model.GetParameters());
-        _out.WriteLine($"SETPARAMS ONLY   worstDelta={Worst(baseline, viaParams.Predict(input)):E3}");
+        double parameterDelta = Worst(baseline, viaParams.Predict(input));
 
-        Assert.True(true, "localization only");
+        _out.WriteLine($"clone {cloneDelta:E3}, serialize/deserialize {serializeDelta:E3}, parameters only {parameterDelta:E3}");
+        Assert.True(cloneDelta <= Tolerance, $"Clone() diverged from the original by {cloneDelta:E3}.");
+        Assert.True(serializeDelta <= Tolerance, $"A serialize/deserialize round-trip diverged by {serializeDelta:E3}.");
+        Assert.True(parameterDelta <= Tolerance, $"Copying the parameter vector alone diverged by {parameterDelta:E3}.");
     }
 }

--- a/tests/AiDotNet.Tests/Performance/SenseVoiceTrainStepProfile.cs
+++ b/tests/AiDotNet.Tests/Performance/SenseVoiceTrainStepProfile.cs
@@ -25,6 +25,10 @@ using Xunit.Abstractions;
 
 namespace AiDotNet.Tests.Performance;
 
+// SerialPerf: its budgets are wall-clock milliseconds, so it runs in the serialized performance
+// shards, not beside parallel test collections that would make it measure machine load. It had never
+// run in CI at all until then - no shard filter selected AiDotNet.Tests.Performance.
+[Trait("Category", "SerialPerf")]
 public class SenseVoiceTrainStepProfile
 {
     private readonly ITestOutputHelper _output;

--- a/tests/AiDotNet.Tests/SelfSupervisedLearning/ContrastiveObjectiveGradientTests.cs
+++ b/tests/AiDotNet.Tests/SelfSupervisedLearning/ContrastiveObjectiveGradientTests.cs
@@ -25,10 +25,12 @@ namespace AiDotNet.Tests.SelfSupervisedLearning;
 /// </remarks>
 public class ContrastiveObjectiveGradientTests
 {
-    private static Tensor<double> Sample(int rows, int cols, int seed)
+    private static Tensor<double> Sample(int rows, int cols, int seed) => Sample(new[] { rows, cols }, seed);
+
+    private static Tensor<double> Sample(int[] shape, int seed)
     {
         var rng = new Random(seed);
-        var t = new Tensor<double>(new[] { rows, cols });
+        var t = new Tensor<double>(shape);
         for (int i = 0; i < t.Length; i++) t[i] = rng.NextDouble() * 2 - 1;
         return t;
     }
@@ -49,13 +51,21 @@ public class ContrastiveObjectiveGradientTests
         _ => throw new ArgumentOutOfRangeException(nameof(name)),
     };
 
+    /// <summary>
+    /// The input shape each objective is defined on. The embedding objectives take [batch, dim];
+    /// MAE reconstructs PATCHES and validates rank-3 [batch, patches, patch_dim]. A rank-2 input used
+    /// to be silently normalized by the wrong count, so the loss now rejects it rather than guessing.
+    /// </summary>
+    private static int[] ShapeFor(string name) => name == "MAE" ? new[] { 2, 2, 3 } : new[] { 4, 3 };
+
     [Theory]
     [MemberData(nameof(Objectives))]
     public void Objective_ProducesFiniteNonZeroGradient(string name)
     {
-        const int rows = 4, cols = 3;
-        var view1 = Sample(rows, cols, 11);
-        var view2 = Sample(rows, cols, 29);
+        var shape = ShapeFor(name);
+        int cols = shape[^1];
+        var view1 = Sample(shape, 11);
+        var view2 = Sample(shape, 29);
         var loss = Create(name, cols);
 
         using var tape = new GradientTape<double>();
@@ -84,9 +94,10 @@ public class ContrastiveObjectiveGradientTests
     [MemberData(nameof(Objectives))]
     public void Objective_GradientMatchesFiniteDifferences(string name)
     {
-        const int rows = 4, cols = 3;
-        var view1 = Sample(rows, cols, 7);
-        var view2 = Sample(rows, cols, 13);
+        var shape = ShapeFor(name);
+        int cols = shape[^1];
+        var view1 = Sample(shape, 7);
+        var view2 = Sample(shape, 13);
         var loss = Create(name, cols);
 
         using var tape = new GradientTape<double>();


### PR DESCRIPTION
## Summary

A set of tests in this repository had never actually executed — no shard filter selected their classes, so they were compiled, counted as "present", and never run. When they were finally run they failed. This branch fixes them: five of the failures turned out to be real product defects, and the rest were test expectations that had drifted from the code while nobody was watching.

Four source files and six test files change. Nothing is deleted from the product surface except one dead `protected` helper (see Blast radius).

The product defects repaired here:

- a `DeepCopy()` clone serialized to different bytes than the model it was cloned from, and a clone taken mid-training silently switched dropout and batch statistics off;
- `ResolveShapes` drove the bare layer loop instead of the model's own inference entry point, so a model that reshapes its input in `PredictCore` threw from the very method its own `SetParameters` error tells the user to call;
- every cloned `BarkModel<T>` was rebuilt around a *different, untrained* codec;
- `VideoMAE<T>`'s default architecture declared a single frame, which its own patch embedder folds into zero tubelets and an empty batch;
- `RandomSampling<T>` accepted a seed and ignored it — every seed picked the identical samples.

---

## Per-fix table

Line references are to `origin/master` `3185b41f1` unless stated otherwise.

### Source fixes

| # | Defect | Root cause | Before → After |
|---|---|---|---|
| 1 | A clone did not serialize like its source, and a clone taken while training came back in inference mode | `src/NeuralNetworks/NeuralNetworkBase.cs:15363` — every branch of `DeepCopy()` restores through the layer deserializer, which deliberately leaves a restored model in **inference** mode (correct for a model loaded from bytes, wrong for a clone). Invisible until training mode became serialized state (#1789) | `DeepCopy()` now wraps a new `DeepCopyRestoredInInferenceMode()` and reapplies the source's training mode afterwards (branch `NeuralNetworkBase.cs:15389`, `:15398`). `Deserialize` is untouched: loading a model still starts it in inference mode |
| 2 | Per-instance scratch was written into the persisted state envelope, so a copy could never match its original byte for byte | `NeuralNetworkBase.cs:2910` (`_layerStructureVersion`), `:5323`–`:5327` (five `_propagationShadow*` fields), `:12057` (`_pendingFusedMissReason`), `:12075` (`_loggedFusedFallback`) — all unannotated, and declared state is persisted **by default** | Each marked `[AiDotNet.Attributes.Scratch]`, which `ModelStateGenerator.cs:230` skips. Justified field by field under Blast radius |
| 3 | `ResolveShapes` skipped the preprocessing a model does in `PredictCore` | `NeuralNetworkBase.cs:2843` — `_ = ForwardWithMemory(sampleInput);` feeds the caller's raw sample straight to `Layers[0]`. `MusicSourceSeparator` turns a `[B, samples]` waveform into the `[B, 1, samples]` its first `Conv1D` needs inside `PredictCore`, not in `ForwardWithMemory` | `NeuralNetworkBase.cs:2846` (branch) — `_ = Predict(sampleInput);`. `Predict` also owns the eval-mode transition and restores the prior mode, so the hand-rolled `SetTrainingMode(false)`/`finally`-restore wrapper is removed as redundant rather than dropped |
| 4 | Every `BarkModel<T>` clone was built around a fresh default `EnCodec` instead of the codec the model was constructed with | `src/TextToSpeech/CodecBased/BarkModel.cs:645` — the injected codec lives only inside `_codec`, whose type is the *wrapping layer*, so no member on the model could supply the constructor's `codec` argument. The generated clone plan passed its default, `null`. A hand-written `CreateCodecForNewInstance` meant to prevent exactly this was never called by anything | `[ParameterAlias(nameof(_codec))] private IAudioCodec<T> Codec => _codec.Codec;` — the plan can now find the codec by name, and `CloneEngine` already applies the policy that dead method described (clone a codec with a clone contract, share a stateless one). Because it is a `[ParameterAlias]` of `_codec`, nothing is counted or restored twice. Observed effect: the tiny test configuration reported **29,026** parameters on a clone against **28,337** on its source |
| 5 | `new VideoMAE<T>()`'s declared input shape was an input the model cannot accept | `src/Video/ActionRecognition/VideoMAE.cs:149` — the default architecture was `InputType.ThreeDimensional`, whose `GetInputShape()` is `[channels, height, width]` = a **single frame**. VideoMAE reads a rank-4 input as an unbatched clip `[T, C, H, W]`, and `PatchEmbed` folds frames in tubelets of 2: 1 / 2 = **0 tubelets**, i.e. an empty `[0, 6, 224, 224]` batch for the tubelet convolution | `InputType.FourDimensional` with `inputFrames: 16`, in lockstep with the native constructor's `numFrames = 16` default. The XML example at `VideoMAE.cs:52` is updated to match |
| 6 | A clip shorter than one tubelet failed inside the engine rather than at the input | `VideoMAE.cs`, `PatchEmbed` — the empty tubelet batch reached the engine's bias broadcast inside `Layers[0]` | An explicit `ArgumentException` naming the tubelet size, the frame count received, and the accepted layout. Trailing frames beyond a whole tubelet are still dropped, exactly as the reference strided `Conv3d` drops them, so **only** the too-short case is an error |
| 7 | `RandomSampling<T>` accepted a seed and ignored it | `src/ActiveLearning/RandomSampling.cs:120` — `uint hash = (uint)(i * 2654435761L);` hashes the sample index and features with no reference to the seed, so every instance ranked a pool identically. "Random" sampling was a fixed ordering of the data | A per-instance `_salt` drawn from the seeded `Random`, mixed into the hash plus one extra multiplicative step. Deliberately still *deterministic per instance*, because the scoring contract requires stable ranking (the k=1 pick must lie inside the k=5 picks) — the salt is what makes two different seeds rank the pool differently |

### Test repairs

| # | Test | What had drifted | Fix |
|---|---|---|---|
| 8 | `ContrastiveObjectiveGradientTests` (both theories) | The suite fed every objective a rank-2 `[4, 3]` input. MAE reconstructs **patches** and validates rank-3 `[batch, patches, patch_dim]`; a rank-2 input used to be silently normalized by the wrong count, and the loss now rejects it rather than guessing | A `ShapeFor(name)` helper: `[2, 2, 3]` for MAE, `[4, 3]` for the embedding objectives; `Sample` gains an `int[] shape` overload |
| 9 | `PrivBayesDifferentialPrivacyTests.DegenerateBudgetSplit_DoesNotProduceNaN` | Asserted graceful degradation at budget fractions 0.0 and 1.0. `BayesianNetworkSynthOptions` since began **rejecting** those: at 1.0 the conditional distributions would be published with no privacy noise while DP still reported as enabled, and at 0.0 the structure would be learned non-privately | Renamed to `DegenerateBudgetSplit_IsRejected` asserting `ArgumentOutOfRangeException`. The original graceful-degradation intent is preserved in a **new** `ExtremeLegalBudgetSplit_DoesNotProduceNaN` at 0.001 / 0.999 |
| 10 | `TrainingRecipeIntegrationTests` (VAR recipe) | Fixture data was `features[i,1] = i * 0.5` against `features[i,0] = i` — perfectly collinear. VAR regresses each series on the lags of both, so the lag columns are linearly dependent, `X'X` is singular, and OLS is genuinely unidentified. The model correctly refused with a zero-pivot error rather than inventing coefficients | Non-collinear data: `Math.Sin(i*0.3) + i*0.05` and `Math.Cos(i*0.17) - i*0.02` |
| 11 | `SenseVoiceTrainStepProfile` | Its budgets are wall-clock milliseconds, and no shard filter selected `AiDotNet.Tests.Performance` at all, so it had never run anywhere | `[Trait("Category", "SerialPerf")]`, so it runs in the serialized performance shards instead of beside parallel collections that would make it measure machine load |
| 12 | `MssCloneVsSerializeLocalization.Localize` | A localization **scaffold** that printed three deltas and ended in `Assert.True(true, "localization only")` — it could not fail. It also built a 64-sample input, which went stale when the paper-default configuration began requiring ≥ 4096 samples | Rewritten as `CloneSerializeAndParameterCopy_ReproduceTheOriginalPrediction`, asserting all three copy paths (COW clone, serialize/deserialize round-trip, bare parameter-vector copy) reproduce the original prediction to 1e-9. Uses the same smoke-scale Demucs the generated `ModelFamily` scaffold uses — the paper defaults build a 100.6M-parameter `double` fixture peaking at several GiB, and this test would hold four of them |

---

## Which tests failed before, and their pre-fix failure messages

**On the verbatim messages — an honest accounting.** Only two pre-fix failure strings are recorded verbatim anywhere in the commit record, and they survive in the source comments the fixes added. The rest of the pre-fix failures are described in the commit messages in prose but their exact exception text was **not** captured, so it is not reproduced here rather than invented. Re-running to recover them would cost the 2.5-hour suite this PR is already evidenced against.

**Recorded verbatim:**

| Test / path | Pre-fix failure (verbatim, as recorded in the fix's own source comment) |
|---|---|
| `MssCloneVsSerializeLocalization` → `NeuralNetworkBase.ResolveShapes` | `Conv1DLayer requires rank-3 input` — thrown from the very method `SetParameters`' own error message directs the caller to |
| `VideoMAE` default-architecture probe → engine bias broadcast inside `Layers[0]` | `Inner left-operand block exceeds its span` — an opaque engine-internal error, with no statement of what was wrong with the input |

**Described in the commit record, exact text not captured:**

| Test | Recorded pre-fix behaviour |
|---|---|
| `ActiveLearningIntegrationTests.RandomSampling_DifferentSeeds_ProduceDifferentSelections` | Passed vacuously — it asserted only the two selection *lengths*. With the seed ignored, seeds 42 and 123 returned identical selections and the test could not tell. It now asserts `Assert.NotEqual(selected1, selected2)`; both seeds are fixed, so this is deterministic, not a probabilistic "very likely" |
| `ActiveLearningIntegrationTests.RandomSampling_InformativenessScores_AreUniform` | Asserted every score was **equal**. `RandomSampling` deliberately stopped doing that, because with equal scores the top-k order is arbitrary and a k=1 selection was not guaranteed to lie inside the k=5 selection. Renamed to `..._AreStableDrawsInTheUnitInterval` |
| `PrivBayesDifferentialPrivacyTests.DegenerateBudgetSplit_DoesNotProduceNaN` | `ArgumentOutOfRangeException` from `BayesianNetworkSynthOptions.StructureBudgetFraction` at 0.0 and 1.0, where the test expected graceful degradation |
| `TrainingRecipeIntegrationTests` (VAR) | A zero-pivot / singular-matrix error from the OLS solve on the collinear fixture |
| `ContrastiveObjectiveGradientTests` (MAE theory rows) | The MAE objective's rank-3 input validation rejecting the shared rank-2 `[4, 3]` fixture |
| `BarkModel` clone | No exception — a silent wrong answer: the clone carried a different, untrained codec and reported **29,026** parameters against the source's **28,337** |
| `SenseVoiceTrainStepProfile` | Never executed in any shard; not a failure, an absence |

---

## Test evidence

Measured on this branch at `eaf573116`. Not re-run for this PR: `origin/master` has not moved from `3185b41f1` since these runs.

**Targeted suite** (the repaired classes and their neighbours), net10.0:

```
Failed: 0, Passed: 212, Skipped: 1, Total: 213
```

**Broad suite**, net10.0:

```
Failed: 2, Passed: 4371, Skipped: 10, Total: 4383, Duration: 2 h 26 m
```

The 2 remaining failures are pre-existing and are **not** regressions from this branch. That is not an assertion — it was proven, and the proof is below.

---

## Proof that the 2 remaining failures are pre-existing

The two failures are:

- `SequenceTokenSliceLayerShapeContractTests.DeepCopy_AfterBatchedForward_PreservesSliceToDenseShapeContract`
- `HrePaperAChainShapeValidatorTests.HreChain_DeepCopyAfterForward_PassesRevalidation`

Both were run against **`origin/master` `3185b41f1`** and against **this branch `eaf573116`**, on all three target frameworks:

| Framework | `origin/master` `3185b41f1` | this branch `eaf573116` |
|---|---|---|
| net10.0 | Failed 2 / Passed 4 / Total 6 | Failed 2 / Passed 4 / Total 6 |
| net8.0 | Failed 2 / Passed 4 / Total 6 | Failed 2 / Passed 4 / Total 6 |
| net471 | Failed 2 / Passed 4 / Total 6 | Failed 2 / Passed 4 / Total 6 |

Same two tests, same exception **types**, same exception **messages**, same stacks, on both sides.

**Neither test file is touched by this branch.** `git diff --stat 3185b41f1..HEAD` restricted to both files produces no output, and no commit on this branch touches either path.

The exceptions:

```
System.ArgumentException : The first layer's input size (8) must match the input size (128).
```
thrown from `NeuralNetworkArchitecture.ValidateInputDimensions()` (`NeuralNetworkArchitecture.cs:1090`) via `CloneForModelConstruction()` (`:1369`) ← `CloneEngine.CopyConfiguration` (`CloneEngine.cs:149`) ← `CreateNewInstance()` ← `TryDeepCopyCopyOnWrite()` ← `DeepCopy()`.

```
System.NotSupportedException : Layer type ...FixedShapeRank2Layer is not supported for deserialization.
```
from `DeserializationHelper.CreateLayerFromType` (`DeserializationHelper.cs:140`), via the same clone path.

**Why the stacks differ by one frame, and why that is not a behaviour change.** On this branch both stacks carry one extra frame: `DeepCopyRestoredInInferenceMode()`, which is fix #1's rename of `DeepCopy`'s own body. That frame is the split itself and nothing more. Specifically:

- both throws happen inside `CreateNewInstance()`, **before** the new `SetTrainingMode` line is ever reached, so fix #1's added behaviour cannot be implicated;
- `ResolveShapes` appears on **neither** stack, so fix #3 cannot be implicated either.

---

## Blast radius and file map

| File | Change | Who is affected |
|---|---|---|
| `src/NeuralNetworks/NeuralNetworkBase.cs` | `DeepCopy` split; eight fields marked `[Scratch]`; `ResolveShapes` drives `Predict` | **Every neural network in the library.** The widest-reaching file here |
| `src/TextToSpeech/CodecBased/BarkModel.cs` | dead `protected CreateCodecForNewInstance` removed, `[ParameterAlias]` `Codec` property added | `BarkModel<T>` only — plus a public-surface note below |
| `src/Video/ActionRecognition/VideoMAE.cs` | default architecture is a 16-frame clip; explicit too-short-clip error | `VideoMAE<T>` only |
| `src/ActiveLearning/RandomSampling.cs` | seed salted into the score hash | `RandomSampling<T>` only. **Selections change**: any caller that recorded which samples a given seed picked will now get a different (and actually seed-dependent) set |
| 6 test files | expectations repaired, one scaffold turned into a real test | tests only |

### What `[Scratch]` means here

`src/AiDotNet.Generators/ModelStateGenerator.cs` emits the declared-state envelope, and since that generator was introduced, **member storage is persisted by default** — a member has to say why it should *not* be. At `ModelStateGenerator.cs:230` the generator `continue`s past four kinds it would be wrong to persist — `Trainable` (already in the parameter vector), **`Scratch`** (a work buffer whose value between calls means nothing), `Alias` (another name for a member already carried), and `External` (not this model's to save) — so no `Declare…` call is emitted for them.

The practical consequence, and the reason it fixes anything: **marking a field `[Scratch]` removes it from the persisted state envelope, and therefore from every `Serialize()` and from every clone that restores through that envelope.** It is also not restored — a deserialized or cloned model starts with these fields at their defaults.

Each field, and why that is correct for it:

| Field | Why it is scratch |
|---|---|
| `_layerStructureVersion` | A cache key for `TapeTrainingStep`, keyed to **this** instance's layer list and meaningless on any other. Restoring a model rebuilds its layer list and so advances its own counter — persisted, a clone's bytes could *never* match the model it was cloned from |
| `_propagationShadowAgreedBatched` | Diagnostic tally of shape-propagation agreement; the clone re-walks its shapes and records its own |
| `_propagationShadowAgreedPerSample` | Same |
| `_propagationShadowDeclined` | Same |
| `_propagationShadowDisagreedBoth` | Same |
| `_propagationShadowDisagreements` | Same — the report strings behind those tallies |
| `_pendingFusedMissReason` | Already reset at the top of every `TrainWithTape` call so a prior step's bail-out cannot leak into this one; between calls it carries nothing |
| `_loggedFusedFallback` | A "have I already warned" latch for log de-duplication. Resetting it on a clone costs at most one repeated warning |

None of the eight feeds a prediction. All eight are per-instance bookkeeping, which is precisely the definition `ScratchAttribute` documents.

Two notes for reviewers on this attribute:

1. `ScratchAttribute`'s own XML documentation is worded for **tensor** fields ("Marks a tensor field as transient working state"). These eight are `int`, `bool`, `string?` and `List<string>?`. The attribute's `AttributeUsage` permits any field or property and `ModelStateGenerator` dispatches on the classified *kind*, not on the member's type, so the usage is supported and behaves as intended — but the attribute's prose has not been widened to match, and this PR does not widen it.
2. `[Scratch]` is also honoured by `ActivationCacheGuardAnalyzer` and `ParameterAutomationAnalyzer`, where it suppresses weight-capable-field diagnostics. None of these eight fields is weight-capable, so no diagnostic is being silenced.

### Public-surface note

`BarkModel<T>.CreateCodecForNewInstance` was `protected` and is removed. It was **dead in-tree** — nothing called it, which is precisely the bug. Removing it is nonetheless a source-breaking change for any external subclass of `BarkModel<T>` that called or overrode it; the replacement `Codec` member is `private` because only the generated clone plan needs to see it.

---

## What this does not do

**It does not fix the two copy-on-write clone defects that cause the 2 remaining failures.** Both live in `NeuralNetworkArchitecture.CloneForModelConstruction()` on the COW clone path, and both are held here pending a scope decision rather than fixed opportunistically inside a test-repair branch:

1. **Constructor re-derivation defeats input validation.** `CloneForModelConstruction()` re-runs the architecture constructor, so an architecture whose input layer is `[8, 16]` has its `inputSize` re-derived as 128 and then validated against the first layer's input size of 8 — `NeuralNetworkArchitecture.cs:1090`.
2. **The rebuild registry only knows built-in layers.** Layers are rebuilt through `DeserializationHelper`'s hard-coded type registry (`DeserializationHelper.cs:140`), so any custom layer declared outside the AiDotNet core assembly throws `NotSupportedException`. `DeepCopy`'s **eager** path already guards for exactly this, detecting custom layers by assembly identity and forcing the per-layer copy path (`NeuralNetworkBase.cs:15482` on this branch) — but `TryDeepCopyCopyOnWrite` (`:15665`) runs *before* that guard ever executes, so the COW fast path never benefits from it.

Also out of scope:

- No shard or CI filter configuration is changed, beyond the single `[Trait("Category", "SerialPerf")]` on `SenseVoiceTrainStepProfile`. Other classes that no shard selects are not audited here.
- `Deserialize` semantics are unchanged: a model loaded from bytes still starts in inference mode. Only `DeepCopy` now reapplies the source's training mode.
- `ScratchAttribute`'s tensor-worded documentation is not widened (see above).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017otuSGr3GdmvPoYLbiaWR2
